### PR TITLE
Add module navigation and i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+dist/
+package-lock.json

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,8 @@
         "@tauri-apps/plugin-dialog": "~2",
         "@tauri-apps/plugin-opener": "^2",
         "vue": "^3.5.13",
+        "vue-i18n": "^9.14.4",
+        "vue-router": "^4.5.1",
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -76,6 +78,12 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.5", "", { "os": "win32", "cpu": "x64" }, "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g=="],
+
+    "@intlify/core-base": ["@intlify/core-base@9.14.4", "", { "dependencies": { "@intlify/message-compiler": "9.14.4", "@intlify/shared": "9.14.4" } }, "sha512-vtZCt7NqWhKEtHa3SD/322DlgP5uR9MqWxnE0y8Q0tjDs9H5Lxhss+b5wv8rmuXRoHKLESNgw9d+EN9ybBbj9g=="],
+
+    "@intlify/message-compiler": ["@intlify/message-compiler@9.14.4", "", { "dependencies": { "@intlify/shared": "9.14.4", "source-map-js": "^1.0.2" } }, "sha512-vcyCLiVRN628U38c3PbahrhbbXrckrM9zpy0KZVlDk2Z0OnGwv8uQNNXP3twwGtfLsCf4gu3ci6FMIZnPaqZsw=="],
+
+    "@intlify/shared": ["@intlify/shared@9.14.4", "", {}, "sha512-P9zv6i1WvMc9qDBWvIgKkymjY2ptIiQ065PjDv7z7fDqH3J/HBRBN5IoiR46r/ujRcU7hCuSIZWvCAFCyuOYZA=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.4", "", {}, "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="],
 
@@ -169,6 +177,8 @@
 
     "@vue/compiler-vue2": ["@vue/compiler-vue2@2.7.16", "", { "dependencies": { "de-indent": "^1.0.2", "he": "^1.2.0" } }, "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A=="],
 
+    "@vue/devtools-api": ["@vue/devtools-api@6.6.4", "", {}, "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="],
+
     "@vue/language-core": ["@vue/language-core@2.2.12", "", { "dependencies": { "@volar/language-core": "2.4.15", "@vue/compiler-dom": "^3.5.0", "@vue/compiler-vue2": "^2.7.16", "@vue/shared": "^3.5.0", "alien-signals": "^1.0.3", "minimatch": "^9.0.3", "muggle-string": "^0.4.1", "path-browserify": "^1.0.1" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA=="],
 
     "@vue/reactivity": ["@vue/reactivity@3.5.17", "", { "dependencies": { "@vue/shared": "3.5.17" } }, "sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw=="],
@@ -232,6 +242,10 @@
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
     "vue": ["vue@3.5.17", "", { "dependencies": { "@vue/compiler-dom": "3.5.17", "@vue/compiler-sfc": "3.5.17", "@vue/runtime-dom": "3.5.17", "@vue/server-renderer": "3.5.17", "@vue/shared": "3.5.17" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g=="],
+
+    "vue-i18n": ["vue-i18n@9.14.4", "", { "dependencies": { "@intlify/core-base": "9.14.4", "@intlify/shared": "9.14.4", "@vue/devtools-api": "^6.5.0" }, "peerDependencies": { "vue": "^3.0.0" } }, "sha512-B934C8yUyWLT0EMud3DySrwSUJI7ZNiWYsEEz2gknTthqKiG4dzWE/WSa8AzCuSQzwBEv4HtG1jZDhgzPfWSKQ=="],
+
+    "vue-router": ["vue-router@4.5.1", "", { "dependencies": { "@vue/devtools-api": "^6.6.4" }, "peerDependencies": { "vue": "^3.2.0" } }, "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw=="],
 
     "vue-tsc": ["vue-tsc@2.2.12", "", { "dependencies": { "@volar/typescript": "2.4.15", "@vue/language-core": "2.2.12" }, "peerDependencies": { "typescript": ">=5.0.0" }, "bin": { "vue-tsc": "./bin/vue-tsc.js" } }, "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw=="],
   }

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "~2",
     "@tauri-apps/plugin-opener": "^2",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-i18n": "^9.14.4",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
+    "@tauri-apps/cli": "^2",
     "@vitejs/plugin-vue": "^5.2.1",
     "typescript": "~5.6.2",
     "vite": "^6.0.3",
-    "vue-tsc": "^2.1.10",
-    "@tauri-apps/cli": "^2"
+    "vue-tsc": "^2.1.10"
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,42 +1,6 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { open } from '@tauri-apps/plugin-dialog'     // v1-API ¹
-import { invoke } from '@tauri-apps/api/core'
-
-interface DuplicateGroup {
-  hash: string
-  paths: string[]
-}
-
-const duplicates = ref<DuplicateGroup[]>([])
-const busy       = ref(false)
-
-async function chooseAndScan () {
-  const selected = await open({ directory: true, multiple: false })
-  if (!selected) return          // Dialog abgebrochen
-
-  busy.value = true
-  try {
-    duplicates.value = await invoke<DuplicateGroup[]>('scan_folder', {
-      path: selected
-    })
-  } finally {
-    busy.value = false
-  }
-}
 </script>
 
 <template>
-  <button @click="chooseAndScan" :disabled="busy">
-    {{ busy ? 'Scanne…' : 'Ordner auswählen & scannen' }}
-  </button>
-
-  <ul v-if="duplicates.length">
-    <li v-for="d in duplicates" :key="d.hash" class="mt-4">
-      <strong class="text-sm">{{ d.hash }}</strong>
-      <ul class="ml-4 list-disc">
-        <li v-for="p in d.paths" :key="p">{{ p }}</li>
-      </ul>
-    </li>
-  </ul>
+  <router-view />
 </template>

--- a/src/components/Blackhole.vue
+++ b/src/components/Blackhole.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+</script>
+
+<template>
+  <h1>{{ t('blackhole.title') }}</h1>
+</template>

--- a/src/components/Duplicate.vue
+++ b/src/components/Duplicate.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { open } from '@tauri-apps/plugin-dialog'     // v1-API ¹
+import { invoke } from '@tauri-apps/api/core'
+import { useI18n } from 'vue-i18n'
+
+interface DuplicateGroup {
+  hash: string
+  paths: string[]
+}
+
+const duplicates = ref<DuplicateGroup[]>([])
+const busy       = ref(false)
+const { t } = useI18n()
+
+async function chooseAndScan () {
+  const selected = await open({ directory: true, multiple: false })
+  if (!selected) return          // Dialog abgebrochen
+
+  busy.value = true
+  try {
+    duplicates.value = await invoke<DuplicateGroup[]>('scan_folder', {
+      path: selected
+    })
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<template>
+  <button @click="chooseAndScan" :disabled="busy">
+    {{ busy ? t('duplicate.scanning') : t('duplicate.choose') }}
+  </button>
+
+  <ul v-if="duplicates.length">
+    <li v-for="d in duplicates" :key="d.hash" class="mt-4">
+      <strong class="text-sm">{{ d.hash }}</strong>
+      <ul class="ml-4 list-disc">
+        <li v-for="p in d.paths" :key="p">{{ p }}</li>
+      </ul>
+    </li>
+  </ul>
+</template>

--- a/src/components/Import.vue
+++ b/src/components/Import.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+</script>
+
+<template>
+  <h1>{{ t('import.title') }}</h1>
+</template>

--- a/src/components/Sort.vue
+++ b/src/components/Sort.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+</script>
+
+<template>
+  <h1>{{ t('sort.title') }}</h1>
+</template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,36 @@
-import { createApp } from "vue";
-import App from "./App.vue";
+import { createApp } from 'vue'
+import App from './App.vue'
+import router from './router'
+import { createI18n } from 'vue-i18n'
 
-createApp(App).mount("#app");
+const messages = {
+  en: {
+    duplicate: {
+      title: 'Duplicate',
+      choose: 'Choose folder & scan',
+      scanning: 'Scanning…',
+    },
+    import: { title: 'Import' },
+    sort: { title: 'Sort' },
+    blackhole: { title: 'Blackhole' },
+  },
+  de: {
+    duplicate: {
+      title: 'Duplikate',
+      choose: 'Ordner auswählen & scannen',
+      scanning: 'Scanne…',
+    },
+    import: { title: 'Importieren' },
+    sort: { title: 'Sortieren' },
+    blackhole: { title: 'Schwarzes Loch' },
+  },
+}
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages,
+})
+
+createApp(App).use(router).use(i18n).mount('#app')

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,22 @@
+import { createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router'
+
+import Duplicate from '../components/Duplicate.vue'
+import ImportView from '../components/Import.vue'
+import SortView from '../components/Sort.vue'
+import Blackhole from '../components/Blackhole.vue'
+import Home from '../views/Home.vue'
+
+const routes: Array<RouteRecordRaw> = [
+  { path: '/', name: 'home', component: Home },
+  { path: '/duplicate', name: 'duplicate', component: Duplicate },
+  { path: '/import', name: 'import', component: ImportView },
+  { path: '/sort', name: 'sort', component: SortView },
+  { path: '/blackhole', name: 'blackhole', component: Blackhole },
+]
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes,
+})
+
+export default router

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+const { t } = useI18n()
+</script>
+
+<template>
+  <div class="grid grid-cols-2 gap-4">
+    <router-link class="p-4 border rounded" to="/duplicate">{{ t('duplicate.title') }}</router-link>
+    <router-link class="p-4 border rounded" to="/import">{{ t('import.title') }}</router-link>
+    <router-link class="p-4 border rounded" to="/sort">{{ t('sort.title') }}</router-link>
+    <router-link class="p-4 border rounded" to="/blackhole">{{ t('blackhole.title') }}</router-link>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- move duplicate scanning component into its own file
- add Import, Sort and Blackhole components
- add vue-router and vue-i18n
- implement a home screen with links to each module
- provide German and English translations
- remove npm `package-lock.json` to use Bun

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_686bde816e3c8329b161df6af354de14