### PR TITLE
Introduce dark and light theme

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,32 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const theme = ref<'light' | 'dark'>('light')
+
+onMounted(() => {
+  theme.value = window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+})
+
+function toggleTheme() {
+  theme.value = theme.value === 'light' ? 'dark' : 'light'
+}
 </script>
 
 <template>
-  <router-view />
+  <div :data-theme="theme">
+    <header class="app-header">
+      <button @click="toggleTheme">{{ theme === 'dark' ? '☀️' : '🌙' }}</button>
+    </header>
+    <router-view />
+  </div>
 </template>
+
+<style scoped>
+.app-header {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.5rem 1rem;
+}
+</style>

--- a/src/components/Blackhole.vue
+++ b/src/components/Blackhole.vue
@@ -4,5 +4,7 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <h1>{{ t('blackhole.title') }}</h1>
+  <div class="view">
+    <h1>{{ t('blackhole.title') }}</h1>
+  </div>
 </template>

--- a/src/components/Duplicate.vue
+++ b/src/components/Duplicate.vue
@@ -29,16 +29,18 @@ async function chooseAndScan () {
 </script>
 
 <template>
-  <button @click="chooseAndScan" :disabled="busy">
-    {{ busy ? t('duplicate.scanning') : t('duplicate.choose') }}
-  </button>
+  <div class="view">
+    <button @click="chooseAndScan" :disabled="busy">
+      {{ busy ? t('duplicate.scanning') : t('duplicate.choose') }}
+    </button>
 
-  <ul v-if="duplicates.length">
-    <li v-for="d in duplicates" :key="d.hash" class="mt-4">
-      <strong class="text-sm">{{ d.hash }}</strong>
-      <ul class="ml-4 list-disc">
-        <li v-for="p in d.paths" :key="p">{{ p }}</li>
-      </ul>
-    </li>
-  </ul>
+    <ul v-if="duplicates.length" style="margin-top: 1rem;">
+      <li v-for="d in duplicates" :key="d.hash" style="margin-top: 0.5rem;">
+        <strong style="font-size: 0.875rem;">{{ d.hash }}</strong>
+        <ul style="margin-left: 1rem; list-style: disc;">
+          <li v-for="p in d.paths" :key="p">{{ p }}</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
 </template>

--- a/src/components/Import.vue
+++ b/src/components/Import.vue
@@ -4,5 +4,7 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <h1>{{ t('import.title') }}</h1>
+  <div class="view">
+    <h1>{{ t('import.title') }}</h1>
+  </div>
 </template>

--- a/src/components/Sort.vue
+++ b/src/components/Sort.vue
@@ -4,5 +4,7 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <h1>{{ t('sort.title') }}</h1>
+  <div class="view">
+    <h1>{{ t('sort.title') }}</h1>
+  </div>
 </template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 import { createI18n } from 'vue-i18n'
+import './style.css'
 
 const messages = {
   en: {

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,83 @@
+:root {
+  --bg-color: #f5f5f7;
+  --text-color: #1d1d1f;
+  --card-bg: #ffffff;
+  --border-color: #d2d2d2;
+  --accent-color: #007aff;
+}
+
+[data-theme='dark'] {
+  --bg-color: #1d1d1f;
+  --text-color: #f5f5f7;
+  --card-bg: #2c2c2e;
+  --border-color: #3a3a3c;
+  --accent-color: #0a84ff;
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  margin: 0;
+}
+
+a {
+  color: var(--accent-color);
+  text-decoration: none;
+}
+
+.grid-home {
+  max-width: 600px;
+  margin: 2rem auto;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 1rem;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 1rem;
+  text-align: center;
+  transition: background 0.3s, color 0.3s;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.card:hover {
+  background: var(--accent-color);
+  color: #fff;
+}
+
+button {
+  background: var(--accent-color);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-color), #000 10%);
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.view {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -4,10 +4,12 @@ const { t } = useI18n()
 </script>
 
 <template>
-  <div class="grid grid-cols-2 gap-4">
-    <router-link class="p-4 border rounded" to="/duplicate">{{ t('duplicate.title') }}</router-link>
-    <router-link class="p-4 border rounded" to="/import">{{ t('import.title') }}</router-link>
-    <router-link class="p-4 border rounded" to="/sort">{{ t('sort.title') }}</router-link>
-    <router-link class="p-4 border rounded" to="/blackhole">{{ t('blackhole.title') }}</router-link>
+  <div class="view">
+    <div class="grid-home">
+      <router-link class="card" to="/duplicate">{{ t('duplicate.title') }}</router-link>
+      <router-link class="card" to="/import">{{ t('import.title') }}</router-link>
+      <router-link class="card" to="/sort">{{ t('sort.title') }}</router-link>
+      <router-link class="card" to="/blackhole">{{ t('blackhole.title') }}</router-link>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- add global CSS variables for light and dark mode
- detect preferred OS theme and allow toggling
- modernize `Home.vue` grid and card layout
- wrap views in a common container

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686be205720c8329a3cb1a08a47557d9