### PR TITLE
Enable theme-based background

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 
 const theme = ref<'light' | 'dark'>('light')
 
@@ -9,13 +9,21 @@ onMounted(() => {
     : 'light'
 })
 
+watch(
+  theme,
+  (val) => {
+    document.documentElement.setAttribute('data-theme', val)
+  },
+  { immediate: true }
+)
+
 function toggleTheme() {
   theme.value = theme.value === 'light' ? 'dark' : 'light'
 }
 </script>
 
 <template>
-  <div :data-theme="theme">
+  <div>
     <header class="app-header">
       <button @click="toggleTheme">{{ theme === 'dark' ? '☀️' : '🌙' }}</button>
     </header>


### PR DESCRIPTION
## Summary
- update theme initialization to set `data-theme` on `<html>`
- react to theme changes with a watcher and remove container attribute

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686be4ac7c908329bee9a398d3f2893d