### PR TITLE
Add progress events during scan

### DIFF
--- a/src/components/Duplicate.vue
+++ b/src/components/Duplicate.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { open } from '@tauri-apps/plugin-dialog'     // v1-API ¹
 import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
 import { useI18n } from 'vue-i18n'
 
 interface DuplicateGroup {
@@ -10,6 +11,7 @@ interface DuplicateGroup {
 }
 
 const duplicates = ref<DuplicateGroup[]>([])
+const progress   = ref(0)
 const busy       = ref(false)
 const { t } = useI18n()
 
@@ -18,12 +20,30 @@ async function chooseAndScan () {
   if (!selected) return          // Dialog abgebrochen
 
   busy.value = true
+  duplicates.value = []
+  progress.value = 0
+
+  const unlistenProgress = await listen<number>('scan_progress', (e) => {
+    progress.value = e.payload
+  })
+  const unlistenDuplicate = await listen<DuplicateGroup>('duplicate_found', (e) => {
+    const existing = duplicates.value.find(d => d.hash === e.payload.hash)
+    if (existing) {
+      existing.paths = e.payload.paths
+    } else {
+      duplicates.value.push(e.payload)
+    }
+  })
+
   try {
     duplicates.value = await invoke<DuplicateGroup[]>('scan_folder', {
       path: selected
     })
   } finally {
+    unlistenProgress()
+    unlistenDuplicate()
     busy.value = false
+    progress.value = 100
   }
 }
 </script>
@@ -33,6 +53,11 @@ async function chooseAndScan () {
     <button @click="chooseAndScan" :disabled="busy">
       {{ busy ? t('duplicate.scanning') : t('duplicate.choose') }}
     </button>
+
+    <div v-if="busy" style="margin-top: 0.5rem;">
+      <progress :value="progress" max="100" style="width: 100%;"></progress>
+      <span>{{ Math.round(progress) }}%</span>
+    </div>
 
     <ul v-if="duplicates.length" style="margin-top: 1rem;">
       <li v-for="d in duplicates" :key="d.hash" style="margin-top: 0.5rem;">


### PR DESCRIPTION
## Summary
- stream scan progress and duplicates from Rust to UI
- listen for tauri events in the Vue component
- show a progress bar while scanning

## Testing
- `bun run build`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: `gobject-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be6c02ff48329ad5d141934342571