### PR TITLE
Implement saved import path

### DIFF
--- a/src/components/Import.vue
+++ b/src/components/Import.vue
@@ -1,10 +1,31 @@
 <script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { open } from '@tauri-apps/plugin-dialog'
 import { useI18n } from 'vue-i18n'
+
+const destPath = ref<string | null>(null)
 const { t } = useI18n()
+
+onMounted(() => {
+  destPath.value = localStorage.getItem('importDest')
+})
+
+async function chooseDest () {
+  const selected = await open({ directory: true, multiple: false })
+  if (!selected) return
+  const path = Array.isArray(selected) ? selected[0] : selected
+  destPath.value = path
+  localStorage.setItem('importDest', path)
+}
 </script>
 
 <template>
   <div class="view">
+    <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 1rem;">
+      <strong>{{ t('import.destination') }}</strong>
+      <span>{{ destPath || '-' }}</span>
+      <button @click="chooseDest">{{ t('import.choose') }}</button>
+    </div>
     <h1>{{ t('import.title') }}</h1>
   </div>
 </template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,11 @@ const messages = {
       choose: 'Choose folder & scan',
       scanning: 'Scanning…',
     },
-    import: { title: 'Import' },
+    import: {
+      title: 'Import',
+      choose: 'Choose destination',
+      destination: 'Destination:'
+    },
     sort: { title: 'Sort' },
     blackhole: { title: 'Blackhole' },
   },
@@ -21,7 +25,11 @@ const messages = {
       choose: 'Ordner auswählen & scannen',
       scanning: 'Scanne…',
     },
-    import: { title: 'Importieren' },
+    import: {
+      title: 'Importieren',
+      choose: 'Ziel wählen',
+      destination: 'Ziel:'
+    },
     sort: { title: 'Sortieren' },
     blackhole: { title: 'Schwarzes Loch' },
   },


### PR DESCRIPTION
## Summary
- enable selecting an import destination and store it in localStorage
- expose destination label and choose button via i18n

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_686be7f50bb08329b2bf96bdff15b497