### PR TITLE
Add external device listing

### DIFF
--- a/src/components/Import.vue
+++ b/src/components/Import.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { open } from '@tauri-apps/plugin-dialog'
+import { invoke } from '@tauri-apps/api/core'
 import { useI18n } from 'vue-i18n'
 
 const destPath = ref<string | null>(null)
+const devices  = ref<string[]>([])
 const { t } = useI18n()
 
 onMounted(() => {
   destPath.value = localStorage.getItem('importDest')
+  loadDevices()
 })
 
 async function chooseDest () {
@@ -17,6 +20,10 @@ async function chooseDest () {
   destPath.value = path
   localStorage.setItem('importDest', path)
 }
+
+async function loadDevices () {
+  devices.value = await invoke<string[]>('list_external_devices')
+}
 </script>
 
 <template>
@@ -25,6 +32,16 @@ async function chooseDest () {
       <strong>{{ t('import.destination') }}</strong>
       <span>{{ destPath || '-' }}</span>
       <button @click="chooseDest">{{ t('import.choose') }}</button>
+    </div>
+    <div style="margin-bottom: 1rem;">
+      <div style="display: flex; align-items: center; gap: 0.5rem;">
+        <strong>{{ t('import.devices') }}</strong>
+        <button @click="loadDevices">{{ t('import.refresh') }}</button>
+      </div>
+      <ul v-if="devices.length" style="margin-top: 0.5rem;">
+        <li v-for="d in devices" :key="d">{{ d }}</li>
+      </ul>
+      <span v-else>-</span>
     </div>
     <h1>{{ t('import.title') }}</h1>
   </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,9 @@ const messages = {
     import: {
       title: 'Import',
       choose: 'Choose destination',
-      destination: 'Destination:'
+      destination: 'Destination:',
+      devices: 'External devices',
+      refresh: 'Refresh'
     },
     sort: { title: 'Sort' },
     blackhole: { title: 'Blackhole' },
@@ -28,7 +30,9 @@ const messages = {
     import: {
       title: 'Importieren',
       choose: 'Ziel wählen',
-      destination: 'Ziel:'
+      destination: 'Ziel:',
+      devices: 'Externe Geräte',
+      refresh: 'Aktualisieren'
     },
     sort: { title: 'Sortieren' },
     blackhole: { title: 'Schwarzes Loch' },


### PR DESCRIPTION
## Summary
- show removable devices in Import view
- support i18n for device info & refresh button
- implement `list_external_devices` command in Rust backend

## Testing
- `npm run build`
- `cargo build --manifest-path src-tauri/Cargo.toml` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686bea0415308329a57f44bcd80b460a