### PR TITLE
Add progress streaming for duplicate scan

### DIFF
--- a/src-tauri/src/duplicate.rs
+++ b/src-tauri/src/duplicate.rs
@@ -2,8 +2,7 @@ use serde::Serialize;
 use std::{collections::HashMap, fs::File, io::{BufReader, Read}, path::PathBuf, time::Instant};
 use tauri::Emitter;
 use walkdir::WalkDir;
-use blake3::Hasher;
-use tauri::Emitter;               // <-- brings `emit` into scope
+use blake3::Hasher;             // <-- brings `emit` into scope
 
 #[derive(Serialize)]
 pub struct DuplicateGroup {

--- a/src-tauri/src/duplicate.rs
+++ b/src-tauri/src/duplicate.rs
@@ -2,6 +2,7 @@ use serde::Serialize;
 use std::{collections::HashMap, fs::File, io::{BufReader, Read}, path::PathBuf, time::Instant};
 use walkdir::WalkDir;
 use blake3::Hasher;
+use tauri::Emitter;               // <-- brings `emit` into scope
 
 #[derive(Serialize)]
 pub struct DuplicateGroup {
@@ -9,11 +10,12 @@ pub struct DuplicateGroup {
     pub paths: Vec<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]       // <-- now `Clone` as well
 pub struct DuplicateProgress {
     pub progress: f32,
     pub eta_seconds: f32,
 }
+
 
 #[tauri::command]
 pub async fn scan_folder(path: String) -> Result<Vec<DuplicateGroup>, String> {
@@ -65,6 +67,7 @@ fn heavy_scan(root: PathBuf) -> Result<Vec<DuplicateGroup>, String> {
         .map(|(hash, paths)| DuplicateGroup { hash, paths })
         .collect())
 }
+
 
 fn heavy_scan_stream(window: tauri::Window, root: PathBuf) -> Result<Vec<DuplicateGroup>, String> {
     let mut map: HashMap<String, Vec<String>> = HashMap::new();

--- a/src-tauri/src/duplicate.rs
+++ b/src-tauri/src/duplicate.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::{collections::HashMap, fs::File, io::{BufReader, Read}, path::PathBuf};
+use std::{collections::HashMap, fs::File, io::{BufReader, Read}, path::PathBuf, time::Instant};
 use walkdir::WalkDir;
 use blake3::Hasher;
 
@@ -9,10 +9,29 @@ pub struct DuplicateGroup {
     pub paths: Vec<String>,
 }
 
+#[derive(Serialize)]
+pub struct DuplicateProgress {
+    pub progress: f32,
+    pub eta_seconds: f32,
+}
+
 #[tauri::command]
 pub async fn scan_folder(path: String) -> Result<Vec<DuplicateGroup>, String> {
     let duplicates = tauri::async_runtime::spawn_blocking(move || {
         heavy_scan(PathBuf::from(path))
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+    Ok(duplicates)
+}
+
+#[tauri::command]
+pub async fn scan_folder_stream(
+    window: tauri::Window,
+    path: String,
+) -> Result<Vec<DuplicateGroup>, String> {
+    let duplicates = tauri::async_runtime::spawn_blocking(move || {
+        heavy_scan_stream(window, PathBuf::from(path))
     })
     .await
     .map_err(|e| e.to_string())??;
@@ -42,6 +61,52 @@ fn heavy_scan(root: PathBuf) -> Result<Vec<DuplicateGroup>, String> {
     }
 
     Ok(map.into_iter()
+        .filter(|(_, v)| v.len() > 1)
+        .map(|(hash, paths)| DuplicateGroup { hash, paths })
+        .collect())
+}
+
+fn heavy_scan_stream(window: tauri::Window, root: PathBuf) -> Result<Vec<DuplicateGroup>, String> {
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+
+    let paths: Vec<PathBuf> = WalkDir::new(&root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .map(|e| e.path().to_path_buf())
+        .collect();
+
+    let total = paths.len() as f32;
+    let start = Instant::now();
+
+    for (idx, path) in paths.into_iter().enumerate() {
+        let mut reader = BufReader::new(File::open(&path).map_err(|e| e.to_string())?);
+
+        let mut hasher = Hasher::new();
+        let mut buf = [0u8; 8192];
+        loop {
+            let n = reader.read(&mut buf).map_err(|e| e.to_string())?;
+            if n == 0 { break }
+            hasher.update(&buf[..n]);
+        }
+        let hash_hex = hasher.finalize().to_hex().to_string();
+        map.entry(hash_hex).or_default().push(path.display().to_string());
+
+        let scanned = (idx + 1) as f32;
+        let progress = if total > 0.0 { scanned / total } else { 1.0 };
+        let elapsed = start.elapsed().as_secs_f32();
+        let eta = if progress > 0.0 { elapsed / progress * (1.0 - progress) } else { 0.0 };
+        let _ = window.emit(
+            "duplicate_progress",
+            DuplicateProgress {
+                progress,
+                eta_seconds: eta,
+            },
+        );
+    }
+
+    Ok(map
+        .into_iter()
         .filter(|(_, v)| v.len() > 1)
         .map(|(hash, paths)| DuplicateGroup { hash, paths })
         .collect())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             greet,
             duplicate::scan_folder,
+            duplicate::scan_folder_stream,
             importer::list_external_devices,
         ])
         .run(tauri::generate_context!())

--- a/src/components/Duplicate.vue
+++ b/src/components/Duplicate.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onBeforeUnmount } from 'vue'
 import HamsterLoader from './HamsterLoader.vue'
 import { open } from '@tauri-apps/plugin-dialog'     // v1-API ¹
 import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { useI18n } from 'vue-i18n'
 
 interface DuplicateGroup {
@@ -10,8 +11,16 @@ interface DuplicateGroup {
   paths: string[]
 }
 
+interface DuplicateProgress {
+  progress: number
+  eta_seconds: number
+}
+
 const duplicates = ref<DuplicateGroup[]>([])
 const busy       = ref(false)
+const progress   = ref(0)
+const eta        = ref(0)
+let unlisten: UnlistenFn | null = null
 const { t } = useI18n()
 
 async function chooseAndScan () {
@@ -19,14 +28,32 @@ async function chooseAndScan () {
   if (!selected) return          // Dialog abgebrochen
 
   busy.value = true
+  progress.value = 0
+  eta.value = 0
+  if (unlisten) {
+    unlisten()
+    unlisten = null
+  }
+  unlisten = await listen<DuplicateProgress>('duplicate_progress', (e) => {
+    progress.value = e.payload.progress
+    eta.value = e.payload.eta_seconds
+  })
   try {
-    duplicates.value = await invoke<DuplicateGroup[]>('scan_folder', {
+    duplicates.value = await invoke<DuplicateGroup[]>('scan_folder_stream', {
       path: selected
     })
   } finally {
     busy.value = false
+    if (unlisten) {
+      unlisten()
+      unlisten = null
+    }
   }
 }
+
+onBeforeUnmount(() => {
+  if (unlisten) unlisten()
+})
 </script>
 
 <template>
@@ -36,6 +63,9 @@ async function chooseAndScan () {
     </button>
 
     <HamsterLoader v-if="busy" />
+    <div v-if="busy" style="text-align: center; margin-top: 0.5rem;">
+      {{ Math.round(progress * 100) }}% - ETA {{ eta.toFixed(1) }}s
+    </div>
 
     <ul v-if="duplicates.length" style="margin-top: 1rem;">
       <li v-for="d in duplicates" :key="d.hash" style="margin-top: 0.5rem;">


### PR DESCRIPTION
## Summary
- stream duplicate scan progress from backend
- wire up new `scan_folder_stream` in frontend
- show progress info during scanning

## Testing
- `npm run build`
- `cargo check` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686bfe7a7cb483298064ee6de429a934