### PR TITLE
Show external device name and size

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1756,6 +1756,7 @@ dependencies = [
  "blake3",
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -3616,6 +3617,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2187,6 +2187,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2370,16 @@ dependencies = [
  "block2 0.6.1",
  "libc",
  "objc2 0.6.1",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -3626,6 +3645,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
 dependencies = [
  "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,3 +29,4 @@ serde_json = "1"
 tauri-plugin-dialog = "2"
 walkdir = "2"
 blake3  = { version = "1", default-features = false, features = ["rayon"] }
+sysinfo = { version = "0.30", default-features = false }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,4 +29,4 @@ serde_json = "1"
 tauri-plugin-dialog = "2"
 walkdir = "2"
 blake3  = { version = "1", default-features = false, features = ["rayon"] }
-sysinfo = { version = "0.30", default-features = false }
+sysinfo = { version = "0.35.2", default-features = false }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,4 +29,4 @@ serde_json = "1"
 tauri-plugin-dialog = "2"
 walkdir = "2"
 blake3  = { version = "1", default-features = false, features = ["rayon"] }
-sysinfo = { version = "0.35.2", default-features = false }
+sysinfo = "0.35.2"

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1,59 +1,28 @@
-use std::fs;
+use serde::Serialize;
+use sysinfo::{DiskExt, SystemExt};
+
+#[derive(Serialize)]
+pub struct ExternalDevice {
+    pub name: String,
+    pub path: String,
+    pub total: u64,
+}
 
 #[tauri::command]
-pub fn list_external_devices() -> Result<Vec<String>, String> {
-    #[cfg(target_os = "linux")]
-    {
-        let mut result = Vec::new();
-        for base in ["/media", "/run/media"].iter() {
-            if let Ok(entries) = fs::read_dir(base) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if let Ok(subs) = fs::read_dir(&path) {
-                        for sub in subs.flatten() {
-                            if sub.path().is_dir() {
-                                result.push(sub.path().display().to_string());
-                            }
-                        }
-                    }
-                }
-            }
+pub fn list_external_devices() -> Result<Vec<ExternalDevice>, String> {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_disks_list();
+    sys.refresh_disks();
+
+    let mut result = Vec::new();
+    for disk in sys.disks() {
+        if disk.is_removable() {
+            let name = disk.name().to_string_lossy().into_owned();
+            let path = disk.mount_point().to_string_lossy().into_owned();
+            let total = disk.total_space();
+            result.push(ExternalDevice { name, path, total });
         }
-        return Ok(result);
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        let mut result = Vec::new();
-        if let Ok(entries) = fs::read_dir("/Volumes") {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    result.push(path.display().to_string());
-                }
-            }
-        }
-        return Ok(result);
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        use std::process::Command;
-        let output = Command::new("wmic")
-            .args(["logicaldisk", "where", "drivetype=2", "get", "deviceid"])
-            .output()
-            .map_err(|e| e.to_string())?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let mut result = Vec::new();
-        for line in stdout.lines() {
-            let line = line.trim();
-            if !line.is_empty() && line != "DeviceID" {
-                result.push(format!("{}\\", line));
-            }
-        }
-        return Ok(result);
-    }
-
-    #[allow(unreachable_code)]
-    Ok(Vec::new())
+    Ok(result)
 }

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use sysinfo::{DiskExt, SystemExt};
+use sysinfo::Disks;
 
 #[derive(Serialize)]
 pub struct ExternalDevice {
@@ -10,12 +10,10 @@ pub struct ExternalDevice {
 
 #[tauri::command]
 pub fn list_external_devices() -> Result<Vec<ExternalDevice>, String> {
-    let mut sys = sysinfo::System::new();
-    sys.refresh_disks_list();
-    sys.refresh_disks();
+    let mut disks = Disks::new_with_refreshed_list();
 
     let mut result = Vec::new();
-    for disk in sys.disks() {
+    for disk in disks.list() {
         if disk.is_removable() {
             let name = disk.name().to_string_lossy().into_owned();
             let path = disk.mount_point().to_string_lossy().into_owned();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod sort;
 mod blackhole;
 
 pub use duplicate::DuplicateGroup;
+pub use importer::ExternalDevice;
 
 #[tauri::command]
 fn greet(name: &str) -> String {

--- a/src/components/Import.vue
+++ b/src/components/Import.vue
@@ -4,8 +4,14 @@ import { open } from '@tauri-apps/plugin-dialog'
 import { invoke } from '@tauri-apps/api/core'
 import { useI18n } from 'vue-i18n'
 
+interface Device {
+  name: string
+  path: string
+  total: number
+}
+
 const destPath = ref<string | null>(null)
-const devices  = ref<string[]>([])
+const devices  = ref<Device[]>([])
 const { t } = useI18n()
 
 onMounted(() => {
@@ -22,7 +28,18 @@ async function chooseDest () {
 }
 
 async function loadDevices () {
-  devices.value = await invoke<string[]>('list_external_devices')
+  devices.value = await invoke<Device[]>('list_external_devices')
+}
+
+function formatSize (bytes: number) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let size = bytes
+  let i = 0
+  while (size >= 1024 && i < units.length - 1) {
+    size /= 1024
+    i++
+  }
+  return `${size.toFixed(1)} ${units[i]}`
 }
 </script>
 
@@ -39,7 +56,9 @@ async function loadDevices () {
         <button @click="loadDevices">{{ t('import.refresh') }}</button>
       </div>
       <ul v-if="devices.length" style="margin-top: 0.5rem;">
-        <li v-for="d in devices" :key="d">{{ d }}</li>
+        <li v-for="d in devices" :key="d.path">
+          {{ d.name }} ({{ formatSize(d.total) }}) - {{ d.path }}
+        </li>
       </ul>
       <span v-else>-</span>
     </div>


### PR DESCRIPTION
## Summary
- improve device detection on the Rust side using `sysinfo`
- return device name, path and total capacity
- display device info in the Import page with human‑readable sizes

## Testing
- `npm run build`
- `cargo check` *(fails: failed to download from https://index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686bfea743908329ac6be45e3a013091