### PR TITLE
Add import button for external devices

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -527,8 +527,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1754,6 +1756,7 @@ name = "imagemami"
 version = "0.1.0"
 dependencies = [
  "blake3",
+ "chrono",
  "serde",
  "serde_json",
  "sysinfo",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,3 +30,4 @@ tauri-plugin-dialog = "2"
 walkdir = "2"
 blake3  = { version = "1", default-features = false, features = ["rayon"] }
 sysinfo = "0.35.2"
+chrono = "0.4"

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -1,5 +1,8 @@
 use serde::Serialize;
 use sysinfo::Disks;
+use std::{fs, path::PathBuf};
+use walkdir::WalkDir;
+use chrono::prelude::*;
 
 #[derive(Serialize)]
 pub struct ExternalDevice {
@@ -23,4 +26,49 @@ pub fn list_external_devices() -> Result<Vec<ExternalDevice>, String> {
     }
 
     Ok(result)
+}
+
+#[tauri::command]
+pub async fn import_device(device_path: String, dest_path: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        do_import(PathBuf::from(device_path), PathBuf::from(dest_path))
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+    Ok(())
+}
+
+fn do_import(device: PathBuf, dest: PathBuf) -> Result<(), String> {
+    for entry in WalkDir::new(&device).into_iter().filter_map(|e| e.ok()) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let ext = entry
+            .path()
+            .extension()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_lowercase());
+        if let Some(ext) = ext {
+            if !matches!(ext.as_str(), "jpg" | "jpeg" | "png" | "gif") {
+                continue;
+            }
+        } else {
+            continue;
+        }
+
+        let metadata = entry.metadata().map_err(|e| e.to_string())?;
+        let mtime = metadata.modified().map_err(|e| e.to_string())?;
+        let datetime: DateTime<Local> = mtime.into();
+        let year = datetime.format("%Y").to_string();
+        let day = datetime.format("%Y-%m-%d").to_string();
+        let target_dir = dest.join(year).join(day);
+        fs::create_dir_all(&target_dir).map_err(|e| e.to_string())?;
+        let file_name = entry.file_name();
+        let target = target_dir.join(file_name);
+        if !target.exists() {
+            fs::copy(entry.path(), &target).map_err(|e| e.to_string())?;
+        }
+    }
+
+    Ok(())
 }

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -39,7 +39,6 @@ pub fn list_external_devices() -> Result<Vec<ExternalDevice>, String> {
 
 #[tauri::command]
 pub async fn import_device(device_path: String, dest_path: String) -> Result<(), String> {
-    println!("reviced device {device_path} to {dest_path}");
     tauri::async_runtime::spawn_blocking(move || {
         do_import(PathBuf::from(device_path), PathBuf::from(dest_path))
     })

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -11,6 +11,15 @@ pub struct ExternalDevice {
     pub total: u64,
 }
 
+const ALLOWED_EXTENSIONS: &[&str] = &[
+    // Standard-Rasterformate
+    "jpg", "jpeg", "png", "gif", "bmp", "tif", "tiff", "webp",
+    // Moderne / mobile Formate
+    "heic", "heif",
+    // RAW-Formate diverser Kamerahersteller
+    "raw", "arw", "dng", "cr2", "nef", "pef", "rw2", "sr2",
+];
+
 #[tauri::command]
 pub fn list_external_devices() -> Result<Vec<ExternalDevice>, String> {
     let disks = Disks::new_with_refreshed_list();
@@ -30,6 +39,7 @@ pub fn list_external_devices() -> Result<Vec<ExternalDevice>, String> {
 
 #[tauri::command]
 pub async fn import_device(device_path: String, dest_path: String) -> Result<(), String> {
+    println!("reviced device {device_path} to {dest_path}");
     tauri::async_runtime::spawn_blocking(move || {
         do_import(PathBuf::from(device_path), PathBuf::from(dest_path))
     })
@@ -49,7 +59,7 @@ fn do_import(device: PathBuf, dest: PathBuf) -> Result<(), String> {
             .and_then(|s| s.to_str())
             .map(|s| s.to_lowercase());
         if let Some(ext) = ext {
-            if !matches!(ext.as_str(), "jpg" | "jpeg" | "png" | "gif") {
+            if !ALLOWED_EXTENSIONS.iter().any(|ext_ok| ext_ok.eq_ignore_ascii_case(&ext)) {
                 continue;
             }
         } else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub fn run() {
             duplicate::scan_folder,
             duplicate::scan_folder_stream,
             importer::list_external_devices,
+            importer::import_device,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/Import.vue
+++ b/src/components/Import.vue
@@ -31,6 +31,14 @@ async function loadDevices () {
   devices.value = await invoke<Device[]>('list_external_devices')
 }
 
+async function copyDevice (path: string) {
+  if (!destPath.value) return
+  await invoke('import_device', {
+    devicePath: path,
+    destPath: destPath.value
+  })
+}
+
 function formatSize (bytes: number) {
   const units = ['B', 'KB', 'MB', 'GB', 'TB']
   let size = bytes
@@ -56,8 +64,9 @@ function formatSize (bytes: number) {
         <button @click="loadDevices">{{ t('import.refresh') }}</button>
       </div>
       <ul v-if="devices.length" style="margin-top: 0.5rem;">
-        <li v-for="d in devices" :key="d.path">
-          {{ d.name }} ({{ formatSize(d.total) }}) - {{ d.path }}
+        <li v-for="d in devices" :key="d.path" style="display: flex; align-items: center; gap: 0.5rem;">
+          <span>{{ d.name }} ({{ formatSize(d.total) }}) - {{ d.path }}</span>
+          <button @click="copyDevice(d.path)" :disabled="!destPath">{{ t('import.copy') }}</button>
         </li>
       </ul>
       <span v-else>-</span>

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,8 @@ const messages = {
       choose: 'Choose destination',
       destination: 'Destination:',
       devices: 'External devices',
-      refresh: 'Refresh'
+      refresh: 'Refresh',
+      copy: 'Copy images'
     },
     sort: { title: 'Sort' },
     blackhole: { title: 'Blackhole' },
@@ -32,7 +33,8 @@ const messages = {
       choose: 'Ziel wählen',
       destination: 'Ziel:',
       devices: 'Externe Geräte',
-      refresh: 'Aktualisieren'
+      refresh: 'Aktualisieren',
+      copy: 'Bilder kopieren'
     },
     sort: { title: 'Sortieren' },
     blackhole: { title: 'Schwarzes Loch' },


### PR DESCRIPTION
## Summary
- add ability to copy images from removable media
- show copy button for each external device
- wire new import command into Rust backend
- translate new button label

## Testing
- `npm run build`
- `cargo check` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686c13d2cf1c8329ade82b4b3bacb27f