### PR TITLE
Add loading animation for importer

### DIFF
--- a/src/components/DeviceCard.vue
+++ b/src/components/DeviceCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import DotsLoader from './DotsLoader.vue'
 
 interface Device {
   name: string
@@ -11,6 +12,7 @@ const props = defineProps<{
   device: Device
   disabled: boolean
   copyText: string
+  busy: boolean
   formatSize: (bytes: number) => string
 }>()
 
@@ -33,9 +35,15 @@ function onCopy () { emit('import', props.device.path) }
     <p class="device-path">{{ props.device.path }}</p>
     <p class="device-size">{{ props.formatSize(props.device.total) }}</p>
 
-    <button class="btn w-full" :disabled="disabled" @click="onCopy">
+    <button
+      v-if="!props.busy"
+      class="btn w-full"
+      :disabled="disabled || props.busy"
+      @click="onCopy"
+    >
       {{ copyText }}
     </button>
+    <DotsLoader v-else />
   </div>
 </template>
 

--- a/src/components/DotsLoader.vue
+++ b/src/components/DotsLoader.vue
@@ -1,0 +1,64 @@
+<template>
+  <section class="dots-container">
+    <div class="dot" />
+    <div class="dot" />
+    <div class="dot" />
+    <div class="dot" />
+    <div class="dot" />
+  </section>
+</template>
+
+<style scoped>
+.dots-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+}
+
+.dot {
+  height: 20px;
+  width: 20px;
+  margin-right: 10px;
+  border-radius: 10px;
+  background-color: #b3d4fc;
+  animation: pulse 1.5s infinite ease-in-out;
+}
+
+.dot:last-child {
+  margin-right: 0;
+}
+
+.dot:nth-child(1) {
+  animation-delay: -0.3s;
+}
+
+.dot:nth-child(2) {
+  animation-delay: -0.1s;
+}
+
+.dot:nth-child(3) {
+  animation-delay: 0.1s;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(0.8);
+    background-color: #b3d4fc;
+    box-shadow: 0 0 0 0 rgba(178, 212, 252, 0.7);
+  }
+
+  50% {
+    transform: scale(1.2);
+    background-color: #6793fb;
+    box-shadow: 0 0 0 10px rgba(178, 212, 252, 0);
+  }
+
+  100% {
+    transform: scale(0.8);
+    background-color: #b3d4fc;
+    box-shadow: 0 0 0 0 rgba(178, 212, 252, 0.7);
+  }
+}
+</style>

--- a/src/components/Import.vue
+++ b/src/components/Import.vue
@@ -11,6 +11,7 @@ interface Device { name: string; path: string; total: number }
 
 const destPath  = ref<string | null>(null)
 const devices   = ref<Device[]>([])
+const busyPath  = ref<string | null>(null)
 
 onMounted(() => {
   destPath.value = localStorage.getItem('importDest')
@@ -31,7 +32,12 @@ async function loadDevices () {
 
 async function copyDevice (path: string) {
   if (!destPath.value) return
-  await invoke('import_device', { devicePath: path, destPath: destPath.value })
+  busyPath.value = path
+  try {
+    await invoke('import_device', { devicePath: path, destPath: destPath.value })
+  } finally {
+    busyPath.value = null
+  }
 }
 
 function formatSize (bytes: number) {
@@ -66,6 +72,7 @@ function formatSize (bytes: number) {
           :key="d.path"
           :device="d"
           :disabled="!destPath"
+          :busy="busyPath === d.path"
           :copy-text="$t('import.copy')"
           :format-size="formatSize"
           @import="copyDevice" />


### PR DESCRIPTION
## Summary
- create `DotsLoader` animation component
- replace the copy button with loader while importing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c3b9b527c8329b3c8190a390aa6e4