### PR TITLE
Add tag field to duplicate results

### DIFF
--- a/src-tauri/src/duplicate.rs
+++ b/src-tauri/src/duplicate.rs
@@ -6,7 +6,11 @@ use blake3::Hasher;             // <-- brings `emit` into scope
 
 #[derive(Serialize)]
 pub struct DuplicateGroup {
+    /// Tag describing the duplicate detection method. Currently always `"hash"`.
+    pub tag: String,
+    /// Content hash of all files in this group.
     pub hash: String,
+    /// Paths of the duplicate files.
     pub paths: Vec<String>,
 }
 
@@ -64,7 +68,11 @@ fn heavy_scan(root: PathBuf) -> Result<Vec<DuplicateGroup>, String> {
 
     Ok(map.into_iter()
         .filter(|(_, v)| v.len() > 1)
-        .map(|(hash, paths)| DuplicateGroup { hash, paths })
+        .map(|(hash, paths)| DuplicateGroup {
+            tag: "hash".to_string(),
+            hash,
+            paths,
+        })
         .collect())
 }
 
@@ -108,9 +116,15 @@ fn heavy_scan_stream(window: tauri::Window, root: PathBuf) -> Result<Vec<Duplica
         );
     }
 
-    Ok(map
-        .into_iter()
-        .filter(|(_, v)| v.len() > 1)
-        .map(|(hash, paths)| DuplicateGroup { hash, paths })
-        .collect())
+    Ok(
+        map
+            .into_iter()
+            .filter(|(_, v)| v.len() > 1)
+            .map(|(hash, paths)| DuplicateGroup {
+                tag: "hash".to_string(),
+                hash,
+                paths,
+            })
+            .collect(),
+    )
 }

--- a/src/components/Duplicate.vue
+++ b/src/components/Duplicate.vue
@@ -7,6 +7,7 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { useI18n } from 'vue-i18n'
 
 interface DuplicateGroup {
+  tag: string
   hash: string
   paths: string[]
 }
@@ -69,7 +70,7 @@ onBeforeUnmount(() => {
 
     <ul v-if="duplicates.length" style="margin-top: 1rem;">
       <li v-for="d in duplicates" :key="d.hash" style="margin-top: 0.5rem;">
-        <strong style="font-size: 0.875rem;">{{ d.hash }}</strong>
+        <strong style="font-size: 0.875rem;">{{ d.tag }}: {{ d.hash }}</strong>
         <ul style="margin-left: 1rem; list-style: disc;">
           <li v-for="p in d.paths" :key="p">{{ p }}</li>
         </ul>


### PR DESCRIPTION
## Summary
- attach a `tag` label to each duplicate group returned from Tauri backend
- display the new tag in the Duplicate view

## Testing
- `npm run build`
- `cargo check` *(fails: `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cf65a6d0c83298fbf80f11ff4d3dd