### PR TITLE
Add initial Rust tests

### DIFF
--- a/src-tauri/src/duplicate.rs
+++ b/src-tauri/src/duplicate.rs
@@ -114,3 +114,19 @@ fn heavy_scan_stream(window: tauri::Window, root: PathBuf) -> Result<Vec<Duplica
         .map(|(hash, paths)| DuplicateGroup { hash, paths })
         .collect())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn detect_logo_webp_duplicate() {
+        let path = Path::new("../tests/assets").to_string_lossy().to_string();
+        let groups = tauri::async_runtime::block_on(scan_folder(path)).expect("scan failed");
+        assert!(groups.iter().any(|g| {
+            g.paths.iter().any(|p| p.ends_with("dublications/logo.webp")) &&
+            g.paths.iter().any(|p| p.ends_with("copy_source/logo.webp"))
+        }));
+    }
+}

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -81,3 +81,48 @@ fn do_import(device: PathBuf, dest: PathBuf) -> Result<(), String> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use std::fs;
+
+    fn reset_destination() -> PathBuf {
+        let dest = Path::new("../tests/assets/copy_destination");
+        if dest.exists() {
+            fs::remove_dir_all(dest).unwrap();
+        }
+        fs::create_dir_all(dest).unwrap();
+        dest.to_path_buf()
+    }
+
+    #[test]
+    fn import_copies_allowed_files() {
+        let dest = reset_destination();
+        let device = Path::new("../tests/assets/copy_source");
+        tauri::async_runtime::block_on(import_device(
+            device.to_string_lossy().into_owned(),
+            dest.to_string_lossy().into_owned(),
+        ))
+        .expect("import failed");
+
+        let target_dir = dest.join("2025").join("2025-07-09");
+        let mut files: Vec<String> = fs::read_dir(&target_dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        files.sort();
+        assert_eq!(
+            files,
+            vec![
+                "ChatGPT Image 9. Juli 2025, 11_05_13.png", 
+                "logo-icon-33.webp", 
+                "logo-icon.png", 
+                "logo-icon.webp", 
+                "logo.jpg", 
+                "logo.webp",
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a duplicate scanning test that validates `logo.webp` appears twice
- add an importer test that ensures allowed files are copied to dated folders

## Testing
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: `glib-2.0` required by `glib-sys` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6d3b8fc88329ac840fb5e22043a8