### PR TITLE
Add training data recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Since TypeScript cannot handle type information for `.vue` imports, they are shi
 2. Reload the VS Code window by running `Developer: Reload Window` from the command palette.
 
 You can learn more about Take Over mode [here](https://github.com/johnsoncodehk/volar/discussions/471).
+
+## Duplicate training
+
+When reviewing duplicate files in the **Duplicate** view you can now mark each
+file as *Keep*, *Delete* or *Unknown*. These decisions are stored in
+`training.json` inside the application's data directory. The stored information
+can later be used to train an AI model on how you handle duplicates.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1757,6 +1757,7 @@ version = "0.1.0"
 dependencies = [
  "blake3",
  "chrono",
+ "dirs",
  "serde",
  "serde_json",
  "sysinfo",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,3 +28,4 @@ walkdir = "2"
 blake3  = { version = "1", default-features = false, features = ["rayon"] }
 sysinfo = "0.35.2"
 chrono = "0.4"
+dirs = "6"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod duplicate;
 mod importer;
 mod sort;
 mod blackhole;
+mod training;
 
 pub use duplicate::DuplicateGroup;
 pub use importer::ExternalDevice;
@@ -22,6 +23,7 @@ pub fn run() {
             duplicate::scan_folder_stream,
             importer::list_external_devices,
             importer::import_device,
+            training::record_decision,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/training.rs
+++ b/src-tauri/src/training.rs
@@ -1,0 +1,47 @@
+use serde::{Serialize, Deserialize};
+use std::{fs, fs::File, io::{Read}, path::PathBuf};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TrainingEntry {
+    pub tag: String,
+    pub path: String,
+    pub delete: Option<bool>,
+}
+
+fn training_file() -> Option<PathBuf> {
+    dirs::data_dir().map(|p| p.join("imagemami").join("training.json"))
+}
+
+pub fn load_entries() -> Vec<TrainingEntry> {
+    if let Some(path) = training_file() {
+        if let Ok(mut f) = File::open(&path) {
+            let mut contents = String::new();
+            if f.read_to_string(&mut contents).is_ok() {
+                if let Ok(data) = serde_json::from_str(&contents) {
+                    return data;
+                }
+            }
+        }
+    }
+    Vec::new()
+}
+
+pub fn save_entries(entries: &[TrainingEntry]) -> Result<(), String> {
+    if let Some(path) = training_file() {
+        if let Some(dir) = path.parent() {
+            fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        }
+        let json = serde_json::to_string_pretty(entries).map_err(|e| e.to_string())?;
+        fs::write(&path, json).map_err(|e| e.to_string())?;
+        Ok(())
+    } else {
+        Err("Unable to determine data directory".into())
+    }
+}
+
+#[tauri::command]
+pub fn record_decision(tag: String, path: String, delete: Option<bool>) -> Result<(), String> {
+    let mut entries = load_entries();
+    entries.push(TrainingEntry { tag, path, delete });
+    save_entries(&entries)
+}

--- a/src/components/Duplicate.vue
+++ b/src/components/Duplicate.vue
@@ -24,6 +24,14 @@ const eta        = ref(0)
 let unlisten: UnlistenFn | null = null
 const { t } = useI18n()
 
+function recordDecision (tag: string, path: string, value: string) {
+  let del: boolean | null
+  if (value === 'keep') del = false
+  else if (value === 'delete') del = true
+  else del = null
+  invoke('record_decision', { tag, path, delete: del })
+}
+
 async function chooseAndScan () {
   const selected = await open({ directory: true, multiple: false })
   if (!selected) return          // Dialog abgebrochen
@@ -72,7 +80,14 @@ onBeforeUnmount(() => {
       <li v-for="d in duplicates" :key="d.hash" style="margin-top: 0.5rem;">
         <strong style="font-size: 0.875rem;">{{ d.tag }}: {{ d.hash }}</strong>
         <ul style="margin-left: 1rem; list-style: disc;">
-          <li v-for="p in d.paths" :key="p">{{ p }}</li>
+          <li v-for="p in d.paths" :key="p">
+            {{ p }}
+            <select @change="recordDecision(d.tag, p, ($event.target as HTMLSelectElement).value)" style="margin-left: 0.5rem;">
+              <option value="unknown">Unknown</option>
+              <option value="keep">Keep</option>
+              <option value="delete">Delete</option>
+            </select>
+          </li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
## Summary
- store duplicate decisions in a new `training.json`
- expose `record_decision` Tauri command
- allow marking each duplicate path
- document the training storage

## Testing
- `cargo check` *(fails: glib-2.0 missing)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e8f42190c83299df6b0b4d6135475