### PR TITLE
Add training data export

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ When reviewing duplicate files in the **Duplicate** view you can now mark each
 file as *Keep*, *Delete* or *Unknown*. These decisions are stored in
 `training.json` inside the application's data directory. The stored information
 can later be used to train an AI model on how you handle duplicates.
+You can export the collected training data from the **Training Data** section in the main menu.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub fn run() {
             importer::list_external_devices,
             importer::import_device,
             training::record_decision,
+            training::export_training,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/training.rs
+++ b/src-tauri/src/training.rs
@@ -45,3 +45,10 @@ pub fn record_decision(tag: String, path: String, delete: Option<bool>) -> Resul
     entries.push(TrainingEntry { tag, path, delete });
     save_entries(&entries)
 }
+
+#[tauri::command]
+pub fn export_training(path: String) -> Result<(), String> {
+    let entries = load_entries();
+    let json = serde_json::to_string_pretty(&entries).map_err(|e| e.to_string())?;
+    fs::write(&path, json).map_err(|e| e.to_string())
+}

--- a/src/components/TrainingData.vue
+++ b/src/components/TrainingData.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { save } from '@tauri-apps/plugin-dialog'
+import { invoke } from '@tauri-apps/api/core'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+const busy = ref(false)
+
+async function exportFile () {
+  const selected = await save({
+    filters: [{ name: 'JSON', extensions: ['json'] }]
+  })
+  if (!selected) return
+  busy.value = true
+  try {
+    await invoke('export_training', { path: selected })
+  } finally {
+    busy.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="view">
+    <button @click="exportFile" :disabled="busy">
+      {{ busy ? '…' : t('training.export') }}
+    </button>
+  </div>
+</template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,10 @@ const messages = {
       refresh: 'Refresh',
       copy: 'Copy images'
     },
+    training: {
+      title: 'Training Data',
+      export: 'Export file'
+    },
     sort: { title: 'Sort' },
     blackhole: { title: 'Blackhole' },
   },
@@ -35,6 +39,10 @@ const messages = {
       devices: 'Externe Geräte',
       refresh: 'Aktualisieren',
       copy: 'Bilder kopieren'
+    },
+    training: {
+      title: 'Trainingsdaten',
+      export: 'Datei exportieren'
     },
     sort: { title: 'Sortieren' },
     blackhole: { title: 'Schwarzes Loch' },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import Duplicate from '../components/Duplicate.vue'
 import ImportView from '../components/Import.vue'
 import SortView from '../components/Sort.vue'
 import Blackhole from '../components/Blackhole.vue'
+import TrainingData from '../components/TrainingData.vue'
 import Home from '../views/Home.vue'
 
 const routes: Array<RouteRecordRaw> = [
@@ -12,6 +13,7 @@ const routes: Array<RouteRecordRaw> = [
   { path: '/import', name: 'import', component: ImportView },
   { path: '/sort', name: 'sort', component: SortView },
   { path: '/blackhole', name: 'blackhole', component: Blackhole },
+  { path: '/training', name: 'training', component: TrainingData },
 ]
 
 const router = createRouter({

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -10,6 +10,7 @@ const { t } = useI18n()
       <router-link class="card" to="/import">{{ t('import.title') }}</router-link>
       <router-link class="card" to="/sort">{{ t('sort.title') }}</router-link>
       <router-link class="card" to="/blackhole">{{ t('blackhole.title') }}</router-link>
+      <router-link class="card" to="/training">{{ t('training.title') }}</router-link>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- allow exporting collected duplicate training data
- add Training Data screen and menu item
- translate Training Data screen

## Testing
- `npm run build`
- `cargo check` *(fails: `glib-2.0` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e949ea1ec8329a8fcf8a17c95afbf