### PR TITLE
Add duplicate deletion with confirmation

### DIFF
--- a/src-tauri/src/duplicate.rs
+++ b/src-tauri/src/duplicate.rs
@@ -128,3 +128,11 @@ fn heavy_scan_stream(window: tauri::Window, root: PathBuf) -> Result<Vec<Duplica
             .collect(),
     )
 }
+
+#[tauri::command]
+pub fn delete_files(paths: Vec<String>) -> Result<(), String> {
+    for p in paths {
+        std::fs::remove_file(&p).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub fn run() {
             greet,
             duplicate::scan_folder,
             duplicate::scan_folder_stream,
+            duplicate::delete_files,
             importer::list_external_devices,
             importer::import_device,
             training::record_decision,

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ const messages = {
       title: 'Duplicate',
       choose: 'Choose folder & scan',
       scanning: 'Scanning…',
+      deleteMarked: 'Delete marked',
+      confirmDelete: 'Are you sure you want to delete {count} files?'
     },
     import: {
       title: 'Import',
@@ -25,12 +27,15 @@ const messages = {
     },
     sort: { title: 'Sort' },
     blackhole: { title: 'Blackhole' },
+    common: { yes: 'Yes', no: 'No' },
   },
   de: {
     duplicate: {
       title: 'Duplikate',
       choose: 'Ordner auswählen & scannen',
       scanning: 'Scanne…',
+      deleteMarked: 'Markierte löschen',
+      confirmDelete: 'Sicher, dass Sie {count} Dateien löschen wollen?'
     },
     import: {
       title: 'Importieren',
@@ -46,6 +51,7 @@ const messages = {
     },
     sort: { title: 'Sortieren' },
     blackhole: { title: 'Schwarzes Loch' },
+    common: { yes: 'Ja', no: 'Nein' },
   },
 }
 


### PR DESCRIPTION
## Summary
- allow marking duplicates for deletion
- confirm deletion in a modal
- support deleting files via new Tauri command
- localize new UI strings

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686eb1573c348329bc3c9b9f29195bda