### PR TITLE
Add animated home screen banner

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -51,6 +51,8 @@ a {
 
 /* Grid für Startseite */
 .grid-home {
+  position: relative;
+  z-index: 1;
   max-width: 600px;
   margin: 2rem auto;
   display: grid;
@@ -118,6 +120,7 @@ h1 {
 }
 
 .view {
+  position: relative;
   max-width: 900px;
   margin: 0 auto;
   padding: 1.5rem;
@@ -151,4 +154,29 @@ html {
   background: var(--accent-color);
   width: 0;
   transition: width 0.4s ease;
+}
+
+/* Banner text on home screen */
+.preview-banner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-15deg);
+  font-size: 2rem;
+  font-weight: bold;
+  color: var(--accent-color);
+  opacity: 0.25;
+  white-space: nowrap;
+  pointer-events: none;
+  animation: bannerMove 4s ease-in-out infinite;
+  z-index: 0;
+}
+
+@keyframes bannerMove {
+  0%, 100% {
+    transform: translate(-50%, -50%) rotate(-15deg) scale(1);
+  }
+  50% {
+    transform: translate(calc(-50% + 10px), calc(-50% - 10px)) rotate(-15deg) scale(1.1);
+  }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -5,6 +5,7 @@ const { t } = useI18n()
 
 <template>
   <div class="view">
+    <div class="preview-banner">preview - wait for release</div>
     <div class="grid-home">
       <router-link class="card" to="/duplicate">{{ t('duplicate.title') }}</router-link>
       <router-link class="card" to="/import">{{ t('import.title') }}</router-link>


### PR DESCRIPTION
## Summary
- show a moving banner on the home view saying "preview - wait for release"
- place banner behind menu buttons
- style banner with simple scale animation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ebce253c48329843ec9cf8d773485