### PR TITLE
Update build instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENT Anweisungen
+
+Dieses Repository beinhaltet eine Tauri/Vue Anwendung in TypeScript.
+
+## Arbeitsanweisungen
+
+- Formatierung: benutze `prettier` bevor du Dateien committest.
+- Tests: fuehre `bun run build` aus, alternativ `npm run build`, um sicherzustellen, dass der Code kompiliert.
+- Commit messages muessen auf Englisch sein.
+- Erstelle einen kurzen Pull-Request-Text (auf Englisch), der die Aenderungen beschreibt und bestaetigt, dass der Build erfolgreich war.


### PR DESCRIPTION
## Summary
- clarify root guidelines so `bun run build` can be used instead of npm

## Testing
- `npm run build`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_686eea0cd12c8329b887e69e738a6908