### PR TITLE
Setup prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,30 @@
+name: Pre Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag for pre-release'
+        required: true
+      release_name:
+        description: 'Release title'
+        required: true
+      body:
+        description: 'Release notes'
+        required: false
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          name: ${{ inputs.release_name }}
+          body: ${{ inputs.body }}
+          draft: false
+          prerelease: true
+

--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ file as *Keep*, *Delete* or *Unknown*. These decisions are stored in
 `training.json` inside the application's data directory. The stored information
 can later be used to train an AI model on how you handle duplicates.
 You can export the collected training data from the **Training Data** section in the main menu.
+
+## Pre-release builds
+
+Early testers can try unstable builds from GitHub pre-releases. See [docs/PRE_RELEASE.md](docs/PRE_RELEASE.md) for instructions on creating and downloading pre-releases.

--- a/docs/PRE_RELEASE.md
+++ b/docs/PRE_RELEASE.md
@@ -1,0 +1,11 @@
+# Pre-release for testers
+
+This project provides early access builds through GitHub pre-releases. These versions are meant for testing only and may be unstable.
+
+## How to create a pre-release
+1. Run the **Pre Release** workflow on GitHub.
+2. Provide a tag name (for example `v0.1.0-alpha.1`), title and optional release notes.
+3. The workflow will publish a GitHub release marked as a pre-release.
+
+## How to download
+Navigate to the "Releases" section on GitHub and download the latest pre-release from the assets list.


### PR DESCRIPTION
## Summary
- add GitHub workflow to create prereleases
- document how testers can create and download prereleases
- mention prerelease builds in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ee9c5b7848329a48a1b2b6b8a5e12