### PR TITLE
Add Tauri build workflow

### DIFF
--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -1,0 +1,59 @@
+name: Build Tauri App
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to upload assets"
+        required: true
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            bundle: app
+          - os: ubuntu-latest
+            target: flatpak
+            bundle: flatpak
+          - os: ubuntu-latest
+            target: rpm
+            bundle: rpm
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            bundle: app
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v1
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Build front-end
+        run: bun run build
+      - name: Install system deps (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install -y libwebkit2gtk-4.0-dev \
+            build-essential curl wget libssl-dev \
+            libgtk-3-dev squashfs-tools \
+            flatpak flatpak-builder \
+            rpm
+      - name: Build Tauri application
+        run: |
+          if [ "${{ matrix.bundle }}" = "flatpak" ]; then
+            bunx tauri build --bundles flatpak
+          elif [ "${{ matrix.bundle }}" = "rpm" ]; then
+            bunx tauri build --bundles rpm
+          else
+            bunx tauri build --target ${{ matrix.target }}
+          fi
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          files: target/release/bundle/**

--- a/.github/workflows/build-tauri.yml
+++ b/.github/workflows/build-tauri.yml
@@ -17,6 +17,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
             bundle: app
           - os: ubuntu-latest
+            target: deb
+            bundle: deb
+          - os: ubuntu-latest
             target: flatpak
             bundle: flatpak
           - os: ubuntu-latest
@@ -25,33 +28,46 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             bundle: app
+
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Setup bun
+
+      - name: Setup Bun
         uses: oven-sh/setup-bun@v1
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Build front-end
+
+      - name: Build frontend
         run: bun run build
-      - name: Install system deps (Linux only)
+
+      - name: Install system dependencies (Linux only)
         if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install -y libwebkit2gtk-4.0-dev \
-            build-essential curl wget libssl-dev \
-            libgtk-3-dev squashfs-tools \
-            flatpak flatpak-builder \
+          sudo apt install -y \
+            libwebkit2gtk-4.0-dev \
+            build-essential \
+            curl \
+            wget \
+            libssl-dev \
+            libgtk-3-dev \
+            squashfs-tools \
+            flatpak \
+            flatpak-builder \
             rpm
+
       - name: Build Tauri application
         run: |
-          if [ "${{ matrix.bundle }}" = "flatpak" ]; then
+          if [[ "${{ matrix.bundle }}" == "flatpak" ]]; then
             bunx tauri build --bundles flatpak
-          elif [ "${{ matrix.bundle }}" = "rpm" ]; then
+          elif [[ "${{ matrix.bundle }}" == "rpm" ]]; then
             bunx tauri build --bundles rpm
           else
             bunx tauri build --target ${{ matrix.target }}
           fi
+
       - name: Upload release assets
         uses: softprops/action-gh-release@v1
         with:

--- a/docs/PRE_RELEASE.md
+++ b/docs/PRE_RELEASE.md
@@ -3,9 +3,12 @@
 This project provides early access builds through GitHub pre-releases. These versions are meant for testing only and may be unstable.
 
 ## How to create a pre-release
+
 1. Run the **Pre Release** workflow on GitHub.
 2. Provide a tag name (for example `v0.1.0-alpha.1`), title and optional release notes.
 3. The workflow will publish a GitHub release marked as a pre-release.
+4. Trigger the **Build Tauri** workflow with the same tag to build the Windows installer as well as Linux AppImage, Flatpak, and RPM packages.
 
 ## How to download
-Navigate to the "Releases" section on GitHub and download the latest pre-release from the assets list.
+
+After the build completes, open the **Releases** page on GitHub and download the generated assets. You will find an installer for Windows along with Linux AppImage, Flatpak, and RPM packages.


### PR DESCRIPTION
## Summary
- refine GitHub Actions workflow to build Windows and Linux packages
- update docs about building and downloading release assets

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_686f7aaf21888329acc7b1efec5d3599