### PR TITLE
Fix duplicate scan extension support

### DIFF
--- a/src-tauri/src/duplicate.rs
+++ b/src-tauri/src/duplicate.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, fs::File, io::{BufReader, Read}, path::PathBuf, 
 use tauri::Emitter;
 use walkdir::WalkDir;
 use blake3::Hasher;             // <-- brings `emit` into scope
+use crate::file_formats::ALLOWED_EXTENSIONS;
 
 #[derive(Serialize)]
 pub struct DuplicateGroup {
@@ -41,6 +42,13 @@ fn heavy_scan_stream(window: tauri::Window, root: PathBuf) -> Result<Vec<Duplica
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_file())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .and_then(|s| s.to_str())
+                .map(|ext| ALLOWED_EXTENSIONS.iter().any(|ok| ok.eq_ignore_ascii_case(ext)))
+                .unwrap_or(false)
+        })
         .map(|e| e.path().to_path_buf())
         .collect();
 

--- a/src-tauri/src/file_formats.rs
+++ b/src-tauri/src/file_formats.rs
@@ -1,0 +1,8 @@
+pub const ALLOWED_EXTENSIONS: &[&str] = &[
+    // Standard raster formats
+    "jpg", "jpeg", "png", "gif", "bmp", "tif", "tiff", "webp",
+    // Modern / mobile formats
+    "heic", "heif",
+    // RAW formats of various camera vendors
+    "raw", "arw", "dng", "cr2", "nef", "pef", "rw2", "sr2",
+];

--- a/src-tauri/src/importer.rs
+++ b/src-tauri/src/importer.rs
@@ -3,6 +3,7 @@ use sysinfo::Disks;
 use std::{fs, path::PathBuf};
 use walkdir::WalkDir;
 use chrono::prelude::*;
+use crate::file_formats::ALLOWED_EXTENSIONS;
 
 #[derive(Serialize)]
 pub struct ExternalDevice {
@@ -11,14 +12,6 @@ pub struct ExternalDevice {
     pub total: u64,
 }
 
-const ALLOWED_EXTENSIONS: &[&str] = &[
-    // Standard-Rasterformate
-    "jpg", "jpeg", "png", "gif", "bmp", "tif", "tiff", "webp",
-    // Moderne / mobile Formate
-    "heic", "heif",
-    // RAW-Formate diverser Kamerahersteller
-    "raw", "arw", "dng", "cr2", "nef", "pef", "rw2", "sr2",
-];
 
 #[tauri::command]
 pub fn list_external_devices() -> Result<Vec<ExternalDevice>, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,11 +1,13 @@
 mod duplicate;
 mod importer;
+mod file_formats;
 mod sort;
 mod blackhole;
 mod training;
 
 pub use duplicate::DuplicateGroup;
 pub use importer::ExternalDevice;
+pub use file_formats::ALLOWED_EXTENSIONS;
 
 #[tauri::command]
 fn greet(name: &str) -> String {


### PR DESCRIPTION
## Summary
- refactor allowed extensions into shared module
- use same extension filter in duplicate scan as importer

## Testing
- `npx prettier --write . --ignore-unknown`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fb0e9774083299ee5254e0fc5dba9