### PR TITLE
Fix duplicate image preview

### DIFF
--- a/src/components/ImageCard.vue
+++ b/src/components/ImageCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="image-card" :class="{ marked }">
-    <img :src="'file://' + path" alt="duplicate" />
+    <img :src="src" alt="duplicate" />
     <p class="path">{{ path }}</p>
     <div class="actions">
       <button @click="$emit('decision', 'keep')" class="keep">
@@ -14,12 +14,17 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
+import { computed } from "vue";
+import { convertFileSrc } from "@tauri-apps/api/core";
+
+const props = defineProps<{
   path: string;
   marked: boolean;
   keepText: string;
   deleteText: string;
 }>();
+
+const src = computed(() => convertFileSrc(props.path));
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- use `convertFileSrc` helper so duplicate previews load correctly

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_686ffa98e36883298ea9f1d6b01f0a34