### PR TITLE
Add raw image thumbnail support

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,3 +29,5 @@ blake3  = { version = "1", default-features = false, features = ["rayon"] }
 sysinfo = "0.35.2"
 chrono = "0.4"
 dirs = "6"
+image = "0.24"
+base64 = "0.21"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod file_formats;
 mod sort;
 mod blackhole;
 mod training;
+mod preview;
 
 pub use duplicate::DuplicateGroup;
 pub use importer::ExternalDevice;
@@ -27,6 +28,7 @@ pub fn run() {
             importer::import_device,
             training::record_decision,
             training::export_training,
+            preview::generate_thumbnail,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/preview.rs
+++ b/src-tauri/src/preview.rs
@@ -1,0 +1,15 @@
+use std::io::Cursor;
+use image::io::Reader as ImageReader;
+use image::ImageOutputFormat;
+
+#[tauri::command]
+pub fn generate_thumbnail(path: String, max_size: Option<u32>) -> Result<String, String> {
+    let max = max_size.unwrap_or(256);
+    let img = ImageReader::open(&path).map_err(|e| e.to_string())?.decode().map_err(|e| e.to_string())?;
+    let thumbnail = img.thumbnail(max, max);
+    let mut buf = Vec::new();
+    thumbnail
+        .write_to(&mut Cursor::new(&mut buf), ImageOutputFormat::Jpeg(80))
+        .map_err(|e| e.to_string())?;
+    Ok(format!("data:image/jpeg;base64,{}", base64::engine::general_purpose::STANDARD.encode(buf)))
+}

--- a/src/components/ImageCard.vue
+++ b/src/components/ImageCard.vue
@@ -14,7 +14,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { ref, onMounted } from "vue";
+import { invoke } from "@tauri-apps/api/core";
 import { convertFileSrc } from "@tauri-apps/api/core";
 
 const props = defineProps<{
@@ -24,7 +25,19 @@ const props = defineProps<{
   deleteText: string;
 }>();
 
-const src = computed(() => convertFileSrc(props.path));
+const src = ref<string>("");
+
+onMounted(async () => {
+  const ext = props.path.split(".").pop()?.toLowerCase();
+  const rawExts = ["raw", "arw", "dng", "cr2", "nef", "pef", "rw2", "sr2"];
+  if (ext && rawExts.includes(ext)) {
+    src.value = await invoke<string>("generate_thumbnail", {
+      path: props.path,
+    });
+  } else {
+    src.value = convertFileSrc(props.path);
+  }
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add `image` and `base64` crates
- implement `generate_thumbnail` Tauri command
- expose command via invocation handler
- load thumbnails in `ImageCard` for RAW files

Build succeeds: `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6870050d54dc832992dce6252c072707