### PR TITLE
Map duplicate tag labels

### DIFF
--- a/src/components/pages/Duplicate.vue
+++ b/src/components/pages/Duplicate.vue
@@ -16,7 +16,7 @@
 
     <div v-if="duplicates.length" class="duplicate-list">
       <div v-for="d in duplicates" :key="d.hash" class="duplicate-group">
-        <h3>{{ d.tag }}</h3>
+        <h3>{{ tagText(d.tag) }}</h3>
         <div class="image-pair">
           <ImageCard
             v-for="p in d.paths"
@@ -79,6 +79,12 @@ const showConfirm = ref(false);
 const markedCount = computed(() => marked.value.length);
 let unlisten: UnlistenFn | null = null;
 const { t } = useI18n();
+
+function tagText(tag: string) {
+  const key = `duplicate.tags.${tag}`;
+  const result = t(key);
+  return result === key ? tag : result;
+}
 
 function recordDecision(tag: string, path: string, value: string) {
   let del: boolean | null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,9 @@ const messages = {
       confirmDelete: "Are you sure you want to delete {count} files?",
       dragDropInstruction: "Drag and drop",
       orClickToSelect: "or click",
+      tags: {
+        hash: "Exact match",
+      },
     },
     common: {
       keep: "keep",
@@ -45,6 +48,9 @@ const messages = {
       confirmDelete: "Möchtest du wirklich {count} Dateien löschen?",
       dragDropInstruction: "Ziehe einen Ordner hierher",
       orClickToSelect: "oder klicke hier, um einen Ordner auszuwählen",
+      tags: {
+        hash: "Absolut identisch",
+      },
     },
     common: {
       keep: "Behalten",


### PR DESCRIPTION
## Summary
- show user friendly duplicate tags in UI
- add translations for hash tag

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876962e077c83298c5b98ca0e416426