### PR TITLE
Add keep button toggle for duplicates

### DIFF
--- a/src/components/ui/ImageCard.vue
+++ b/src/components/ui/ImageCard.vue
@@ -3,7 +3,7 @@
     <img :src="src" alt="duplicate" />
     <p class="path">{{ path }}</p>
     <div class="actions">
-      <button @click="$emit('decision', 'keep')" class="keep">
+      <button v-if="marked" @click="$emit('decision', 'keep')" class="keep">
         {{ keepText }}
       </button>
       <button @click="$emit('decision', 'delete')" class="delete">


### PR DESCRIPTION
## Summary
- show the keep button in duplicate cards only after marking a file for deletion

## Testing
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68769652ec6483298d99cd72ec5972c7