### PR TITLE
Implement blackhole scanner

### DIFF
--- a/src-tauri/src/blackhole.rs
+++ b/src-tauri/src/blackhole.rs
@@ -1,2 +1,119 @@
-// Module for blackhole related functionality.
-// Currently no commands are implemented.
+use chrono::prelude::*;
+use serde::Serialize;
+use std::{collections::HashMap, fs, path::PathBuf};
+use walkdir::WalkDir;
+
+use crate::file_formats::ALLOWED_EXTENSIONS;
+
+#[derive(Serialize)]
+pub struct BlackholeFolder {
+    pub path: String,
+    pub files: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct BlackholeProgress {
+    pub progress: f32,
+}
+
+#[tauri::command]
+pub async fn scan_blackhole_stream(
+    window: tauri::Window,
+    root_path: String,
+    dest_path: String,
+) -> Result<Vec<BlackholeFolder>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        do_scan_blackhole_stream(window, PathBuf::from(root_path), PathBuf::from(dest_path))
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+fn do_scan_blackhole_stream(
+    window: tauri::Window,
+    root: PathBuf,
+    dest: PathBuf,
+) -> Result<Vec<BlackholeFolder>, String> {
+    let dest = dest.canonicalize().map_err(|e| e.to_string())?;
+    let entries: Vec<_> = WalkDir::new(&root)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .collect();
+    let total = entries.len() as f32;
+    let mut processed = 0f32;
+    let mut map: HashMap<PathBuf, Vec<String>> = HashMap::new();
+
+    for entry in entries {
+        processed += 1.0;
+        if entry.file_type().is_file() {
+            if let Some(ext) = entry.path().extension().and_then(|s| s.to_str()) {
+                if ALLOWED_EXTENSIONS
+                    .iter()
+                    .any(|ok| ok.eq_ignore_ascii_case(ext))
+                {
+                    if let Some(parent) = entry.path().parent() {
+                        if !parent.starts_with(&dest) {
+                            map.entry(parent.to_path_buf())
+                                .or_default()
+                                .push(entry.path().display().to_string());
+                        }
+                    }
+                }
+            }
+        }
+        let _ = window.emit(
+            "blackhole_progress",
+            BlackholeProgress {
+                progress: if total > 0.0 { processed / total } else { 1.0 },
+            },
+        );
+    }
+
+    Ok(map
+        .into_iter()
+        .map(|(p, files)| BlackholeFolder {
+            path: p.display().to_string(),
+            files,
+        })
+        .collect())
+}
+
+#[tauri::command]
+pub async fn import_blackhole(
+    files: Vec<String>,
+    dest_path: String,
+    cut: bool,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        do_import_blackhole(
+            files.into_iter().map(PathBuf::from).collect(),
+            PathBuf::from(dest_path),
+            cut,
+        )
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+fn do_import_blackhole(files: Vec<PathBuf>, dest: PathBuf, cut: bool) -> Result<(), String> {
+    for path in files {
+        let metadata = fs::metadata(&path).map_err(|e| e.to_string())?;
+        let mtime = metadata.modified().map_err(|e| e.to_string())?;
+        let datetime: DateTime<Local> = mtime.into();
+        let year = datetime.format("%Y").to_string();
+        let day = datetime.format("%Y-%m-%d").to_string();
+        let target_dir = dest.join(&year).join(&day);
+        fs::create_dir_all(&target_dir).map_err(|e| e.to_string())?;
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| "Invalid filename".to_string())?;
+        let target = target_dir.join(file_name);
+        if !target.exists() {
+            fs::copy(&path, &target).map_err(|e| e.to_string())?;
+            if cut {
+                let _ = fs::remove_file(&path);
+            }
+        }
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,14 @@
-mod duplicate;
-mod importer;
-mod file_formats;
-mod sort;
 mod blackhole;
-mod training;
+mod duplicate;
+mod file_formats;
+mod importer;
 mod preview;
+mod sort;
+mod training;
 
 pub use duplicate::DuplicateGroup;
-pub use importer::ExternalDevice;
 pub use file_formats::ALLOWED_EXTENSIONS;
+pub use importer::ExternalDevice;
 
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -25,7 +25,10 @@ pub fn run() {
             duplicate::scan_folder_stream,
             duplicate::delete_files,
             importer::list_external_devices,
+            importer::list_all_disks,
             importer::import_device,
+            blackhole::scan_blackhole_stream,
+            blackhole::import_blackhole,
             training::record_decision,
             training::export_training,
             preview::generate_thumbnail,

--- a/src/components/pages/Blackhole.vue
+++ b/src/components/pages/Blackhole.vue
@@ -1,10 +1,156 @@
 <script setup lang="ts">
+import { ref, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
+import { open } from "@tauri-apps/plugin-dialog";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import DestinationSelector from "../ui/DestinationSelector.vue";
+
+interface Device {
+  name: string;
+  path: string;
+  total: number;
+}
+
+interface BlackholeFolder {
+  path: string;
+  files: string[];
+}
+interface BlackholeProgress {
+  progress: number;
+}
+
+const destPath = ref<string | null>(null);
+const devices = ref<Device[]>([]);
+const busyPath = ref<string | null>(null);
+const folders = ref<BlackholeFolder[]>([]);
+const progress = ref(0);
+let unlisten: UnlistenFn | null = null;
 const { t } = useI18n();
+
+onMounted(() => {
+  destPath.value = localStorage.getItem("importDest");
+  loadDevices();
+});
+
+async function chooseDest() {
+  const selected = await open({ directory: true, multiple: false });
+  if (!selected) return;
+  const path = Array.isArray(selected) ? selected[0] : selected;
+  destPath.value = path;
+  localStorage.setItem("importDest", path);
+}
+
+async function loadDevices() {
+  devices.value = await invoke<Device[]>("list_all_disks");
+}
+
+async function scanDisk(path: string) {
+  if (!destPath.value) return;
+  busyPath.value = path;
+  folders.value = [];
+  progress.value = 0;
+  if (unlisten) {
+    unlisten();
+    unlisten = null;
+  }
+  unlisten = await listen<BlackholeProgress>("blackhole_progress", (e) => {
+    progress.value = e.payload.progress;
+  });
+  try {
+    folders.value = await invoke<BlackholeFolder[]>("scan_blackhole_stream", {
+      rootPath: path,
+      destPath: destPath.value,
+    });
+  } finally {
+    busyPath.value = null;
+    if (unlisten) {
+      unlisten();
+      unlisten = null;
+    }
+  }
+}
+
+async function importFolder(folder: BlackholeFolder, cut: boolean) {
+  if (!destPath.value) return;
+  await invoke("import_blackhole", {
+    files: folder.files,
+    destPath: destPath.value,
+    cut,
+  });
+  folders.value = folders.value.filter((f) => f.path !== folder.path);
+}
 </script>
 
 <template>
-  <div class="view">
+  <div class="view blackhole-view">
     <h1>{{ t("blackhole.title") }}</h1>
+    <DestinationSelector
+      :path="destPath"
+      :label="t('import.destination')"
+      :choose-text="t('import.choose')"
+      @choose="chooseDest"
+    />
+
+    <section>
+      <h2>{{ t("blackhole.disks") }}</h2>
+      <div v-if="devices.length" class="devices-grid">
+        <div v-for="d in devices" :key="d.path" class="card device-card">
+          <strong>{{ d.name }}</strong>
+          <p class="device-path">{{ d.path }}</p>
+          <button class="btn" :disabled="!!busyPath" @click="scanDisk(d.path)">
+            {{ t("blackhole.scan") }}
+          </button>
+        </div>
+      </div>
+      <p v-else class="placeholder">-</p>
+    </section>
+
+    <div v-if="busyPath" class="status">{{ Math.round(progress * 100) }}%</div>
+
+    <section v-if="folders.length" class="folder-list">
+      <div v-for="f in folders" :key="f.path" class="card folder-card">
+        <p class="folder-path">{{ f.path }}</p>
+        <p>{{ f.files.length }} {{ t("blackhole.files") }}</p>
+        <div class="actions">
+          <button class="btn" @click="importFolder(f, false)">
+            {{ t("blackhole.copy") }}
+          </button>
+          <button class="btn ghost" @click="importFolder(f, true)">
+            {{ t("blackhole.cut") }}
+          </button>
+        </div>
+      </div>
+    </section>
   </div>
 </template>
+
+<style scoped>
+.blackhole-view {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+.devices-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+.device-path {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+.folder-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.folder-path {
+  font-size: 0.9rem;
+  word-break: break-all;
+}
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,15 @@ const messages = {
       export: "Export file",
     },
     sort: { title: "Sort" },
-    blackhole: { title: "Blackhole" },
+    blackhole: {
+      title: "Blackhole",
+      scan: "Scan",
+      disks: "Drives",
+      folders: "Folders",
+      copy: "Copy",
+      cut: "Cut",
+      files: "files",
+    },
   },
   de: {
     duplicate: {
@@ -65,7 +73,15 @@ const messages = {
       export: "Datei exportieren",
     },
     sort: { title: "Sortieren" },
-    blackhole: { title: "Schwarzes Loch" },
+    blackhole: {
+      title: "Schwarzes Loch",
+      scan: "Scannen",
+      disks: "Laufwerke",
+      folders: "Ordner",
+      copy: "Kopieren",
+      cut: "Ausschneiden",
+      files: "Dateien",
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- add streaming blackhole scanner in Rust
- support copying or moving found files into the import destination
- expose command for listing all disks
- hook new commands into Tauri backend
- implement Blackhole view with progress and import actions
- provide i18n strings for new UI

Build succeeds via `npm run build`.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876641e6a808329a398f7d14e1c44dd