### PR TITLE
Add cancel command for duplicate scanning

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub fn run() {
             greet,
             duplicate::scan_folder_stream,
             duplicate::delete_files,
+            duplicate::cancel_scan,
             importer::list_external_devices,
             importer::import_device,
             training::record_decision,

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ const messages = {
       delete: "delete",
       yes: "Yes",
       no: "No",
+      cancel: "Cancel",
     },
     import: {
       title: "Import",
@@ -57,6 +58,7 @@ const messages = {
       delete: "Löschen",
       yes: "Ja",
       no: "Nein",
+      cancel: "Abbrechen",
     },
     import: {
       title: "Importieren",


### PR DESCRIPTION
## Summary
- introduce an `AtomicBool` flag in the duplicate scanner
- add `cancel_scan` command and wire it in Tauri
- add a cancel button in `Duplicate.vue`
- provide translations for cancel

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_6876c824d1308329b8174c618e714c8d