### PR TITLE
Add perceptual duplicate scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ You can learn more about Take Over mode [here](https://github.com/johnsoncodehk/
 ## Duplicate training
 
 When reviewing duplicate files in the **Duplicate** view you can now mark each
-file as *Keep*, *Delete* or *Unknown*. These decisions are stored in
+file as _Keep_, _Delete_ or _Unknown_. These decisions are stored in
 `training.json` inside the application's data directory. The stored information
 can later be used to train an AI model on how you handle duplicates.
 You can export the collected training data from the **Training Data** section in the main menu.
+
+## Duplicate detection modes
+
+The duplicate scanner can now run in either **Exact** mode using content hashes or in a **Perceptual** mode using dHash. Choose the desired mode in the Duplicate view before starting a scan.
 
 ## Pre-release builds
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,14 +1,14 @@
-mod duplicate;
-mod importer;
-mod file_formats;
-mod sort;
 mod blackhole;
-mod training;
+mod duplicate;
+mod file_formats;
+mod importer;
 mod preview;
+mod sort;
+mod training;
 
 pub use duplicate::DuplicateGroup;
-pub use importer::ExternalDevice;
 pub use file_formats::ALLOWED_EXTENSIONS;
+pub use importer::ExternalDevice;
 
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -23,6 +23,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             greet,
             duplicate::scan_folder_stream,
+            duplicate::scan_folder_dhash_stream,
             duplicate::delete_files,
             importer::list_external_devices,
             importer::import_device,

--- a/src/components/pages/Duplicate.vue
+++ b/src/components/pages/Duplicate.vue
@@ -1,5 +1,9 @@
 <template>
   <div class="view" @drop.prevent="handleDrop" @dragover.prevent>
+    <select v-model="mode" class="mode-picker">
+      <option value="hash">{{ t("duplicate.modes.exact") }}</option>
+      <option value="dhash">{{ t("duplicate.modes.perceptual") }}</option>
+    </select>
     <div
       class="dropzone"
       v-if="!duplicates.length && !busy"
@@ -75,6 +79,7 @@ const busy = ref(false);
 const progress = ref(0);
 const eta = ref(0);
 const marked = ref<string[]>([]);
+const mode = ref("hash");
 const showConfirm = ref(false);
 const markedCount = computed(() => marked.value.length);
 let unlisten: UnlistenFn | null = null;
@@ -114,7 +119,11 @@ async function scanFolder(path: string) {
     eta.value = e.payload.eta_seconds;
   });
   try {
-    duplicates.value = await invoke<DuplicateGroup[]>("scan_folder_stream", {
+    const cmd =
+      mode.value === "dhash"
+        ? "scan_folder_dhash_stream"
+        : "scan_folder_stream";
+    duplicates.value = await invoke<DuplicateGroup[]>(cmd, {
       path,
     });
   } finally {
@@ -227,5 +236,9 @@ onBeforeUnmount(() => {
   padding: 0.75rem 1.5rem;
   border-radius: 0.5rem;
   font-weight: bold;
+}
+
+.mode-picker {
+  margin-bottom: 1rem;
 }
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,8 +14,13 @@ const messages = {
       confirmDelete: "Are you sure you want to delete {count} files?",
       dragDropInstruction: "Drag and drop",
       orClickToSelect: "or click",
+      modes: {
+        exact: "Exact",
+        perceptual: "Perceptual",
+      },
       tags: {
         hash: "Exact match",
+        dhash: "Perceptual match",
       },
     },
     common: {
@@ -48,8 +53,13 @@ const messages = {
       confirmDelete: "Möchtest du wirklich {count} Dateien löschen?",
       dragDropInstruction: "Ziehe einen Ordner hierher",
       orClickToSelect: "oder klicke hier, um einen Ordner auszuwählen",
+      modes: {
+        exact: "Exakt",
+        perceptual: "Perzeptuell",
+      },
       tags: {
         hash: "Absolut identisch",
+        dhash: "Ähnlich",
       },
     },
     common: {


### PR DESCRIPTION
## Summary
- support perceptual dHash scanning in Rust
- select duplicate detection mode in Duplicate.vue
- add translations for the new mode
- document duplicate detection modes

## Testing
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_6876c823983483298d57d31c411ddb23