### PR TITLE
Fix Rust command compile errors

### DIFF
--- a/src-tauri/src/blackhole.rs
+++ b/src-tauri/src/blackhole.rs
@@ -1,8 +1,8 @@
 use chrono::prelude::*;
 use serde::Serialize;
 use std::{collections::HashMap, fs, path::PathBuf};
-use walkdir::WalkDir;
 use tauri::Emitter;
+use walkdir::WalkDir;
 
 use crate::file_formats::ALLOWED_EXTENSIONS;
 
@@ -12,7 +12,7 @@ pub struct BlackholeFolder {
     pub files: Vec<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct BlackholeProgress {
     pub progress: f32,
 }


### PR DESCRIPTION
## Summary
- derive `Clone` for `BlackholeProgress`
- expose `cancel_scan` as a Tauri command

`bun run build` succeeded, while `bun run tauri build` failed due to missing system libraries.


------
https://chatgpt.com/codex/tasks/task_e_6876d074ccb483298bf06c324d6be63e