### PR TITLE
refactor: move page components into views

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,19 +1,19 @@
-import { createRouter, createWebHashHistory, RouteRecordRaw } from "vue-router";
+import { createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router';
 
-import Duplicate from "../components/pages/Duplicate.vue";
-import ImportView from "../components/pages/Import.vue";
-import SortView from "../components/pages/Sort.vue";
-import Blackhole from "../components/pages/Blackhole.vue";
-import TrainingData from "../components/pages/TrainingData.vue";
-import Home from "../views/Home.vue";
+import Duplicate from '../views/Duplicate.vue';
+import ImportView from '../views/Import.vue';
+import SortView from '../views/Sort.vue';
+import Blackhole from '../views/Blackhole.vue';
+import TrainingData from '../views/TrainingData.vue';
+import Home from '../views/Home.vue';
 
 const routes: Array<RouteRecordRaw> = [
-  { path: "/", name: "home", component: Home },
-  { path: "/duplicate", name: "duplicate", component: Duplicate },
-  { path: "/import", name: "import", component: ImportView },
-  { path: "/sort", name: "sort", component: SortView },
-  { path: "/blackhole", name: "blackhole", component: Blackhole },
-  { path: "/training", name: "training", component: TrainingData },
+  { path: '/', name: 'home', component: Home },
+  { path: '/duplicate', name: 'duplicate', component: Duplicate },
+  { path: '/import', name: 'import', component: ImportView },
+  { path: '/sort', name: 'sort', component: SortView },
+  { path: '/blackhole', name: 'blackhole', component: Blackhole },
+  { path: '/training', name: 'training', component: TrainingData },
 ];
 
 const router = createRouter({

--- a/src/views/Blackhole.vue
+++ b/src/views/Blackhole.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
-import { useSettingsStore } from "../../stores/settings";
-import { useI18n } from "vue-i18n";
-import { open } from "@tauri-apps/plugin-dialog";
-import { invoke } from "@tauri-apps/api/core";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import DestinationSelector from "../ui/DestinationSelector.vue";
+import { ref, onMounted } from 'vue';
+import { useSettingsStore } from '../stores/settings';
+import { useI18n } from 'vue-i18n';
+import { open } from '@tauri-apps/plugin-dialog';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import DestinationSelector from '../components/ui/DestinationSelector.vue';
 
 interface Device {
   name: string;
@@ -41,7 +41,7 @@ async function chooseDest() {
 }
 
 async function loadDevices() {
-  devices.value = await invoke<Device[]>("list_all_disks");
+  devices.value = await invoke<Device[]>('list_all_disks');
 }
 
 async function scanDisk(path: string) {
@@ -53,11 +53,11 @@ async function scanDisk(path: string) {
     unlisten();
     unlisten = null;
   }
-  unlisten = await listen<BlackholeProgress>("blackhole_progress", (e) => {
+  unlisten = await listen<BlackholeProgress>('blackhole_progress', (e) => {
     progress.value = e.payload.progress;
   });
   try {
-    folders.value = await invoke<BlackholeFolder[]>("scan_blackhole_stream", {
+    folders.value = await invoke<BlackholeFolder[]>('scan_blackhole_stream', {
       rootPath: path,
       destPath: settings.importDestination,
     });
@@ -72,7 +72,7 @@ async function scanDisk(path: string) {
 
 async function importFolder(folder: BlackholeFolder, cut: boolean) {
   if (!settings.importDestination) return;
-  await invoke("import_blackhole", {
+  await invoke('import_blackhole', {
     files: folder.files,
     destPath: settings.importDestination,
     cut,
@@ -83,7 +83,7 @@ async function importFolder(folder: BlackholeFolder, cut: boolean) {
 
 <template>
   <div class="view blackhole-view">
-    <h1>{{ t("blackhole.title") }}</h1>
+    <h1>{{ t('blackhole.title') }}</h1>
     <DestinationSelector
       :path="settings.importDestination"
       :label="t('import.destination')"
@@ -92,13 +92,13 @@ async function importFolder(folder: BlackholeFolder, cut: boolean) {
     />
 
     <section>
-      <h2>{{ t("blackhole.disks") }}</h2>
+      <h2>{{ t('blackhole.disks') }}</h2>
       <div v-if="devices.length" class="devices-grid">
         <div v-for="d in devices" :key="d.path" class="card device-card">
           <strong>{{ d.name }}</strong>
           <p class="device-path">{{ d.path }}</p>
           <button class="btn" :disabled="!!busyPath" @click="scanDisk(d.path)">
-            {{ t("blackhole.scan") }}
+            {{ t('blackhole.scan') }}
           </button>
         </div>
       </div>
@@ -110,13 +110,13 @@ async function importFolder(folder: BlackholeFolder, cut: boolean) {
     <section v-if="folders.length" class="folder-list">
       <div v-for="f in folders" :key="f.path" class="card folder-card">
         <p class="folder-path">{{ f.path }}</p>
-        <p>{{ f.files.length }} {{ t("blackhole.files") }}</p>
+        <p>{{ f.files.length }} {{ t('blackhole.files') }}</p>
         <div class="actions">
           <button class="btn" @click="importFolder(f, false)">
-            {{ t("blackhole.copy") }}
+            {{ t('blackhole.copy') }}
           </button>
           <button class="btn ghost" @click="importFolder(f, true)">
-            {{ t("blackhole.cut") }}
+            {{ t('blackhole.cut') }}
           </button>
         </div>
       </div>

--- a/src/views/Duplicate.vue
+++ b/src/views/Duplicate.vue
@@ -3,11 +3,11 @@
     <div class="mode-picker">
       <label>
         <input type="checkbox" value="hash" v-model="modes" />
-        {{ t("duplicate.modes.exact") }}
+        {{ t('duplicate.modes.exact') }}
       </label>
       <label>
         <input type="checkbox" value="dhash" v-model="modes" />
-        {{ t("duplicate.modes.perceptual") }}
+        {{ t('duplicate.modes.perceptual') }}
       </label>
     </div>
     <div
@@ -15,15 +15,15 @@
       v-if="!duplicates.length && !busy"
       @click="openDialog"
     >
-      <p>{{ t("duplicate.dragDropInstruction") }}</p>
-      <small>{{ t("duplicate.orClickToSelect") }}</small>
+      <p>{{ t('duplicate.dragDropInstruction') }}</p>
+      <small>{{ t('duplicate.orClickToSelect') }}</small>
     </div>
 
     <HamsterLoader v-if="busy" />
     <div v-if="busy" class="status">
       {{ Math.round(progress * 100) }}% - ETA {{ eta.toFixed(1) }}s
       <button class="ghost cancel-button" @click="cancelScan">
-        {{ t("common.cancel") }}
+        {{ t('common.cancel') }}
       </button>
     </div>
 
@@ -46,7 +46,7 @@
 
     <div v-if="markedCount" class="delete-bar">
       <button class="delete-button" @click="deleteMarked">
-        {{ t("duplicate.deleteMarked") }}
+        {{ t('duplicate.deleteMarked') }}
       </button>
     </div>
 
@@ -63,14 +63,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onBeforeUnmount } from "vue";
-import { invoke } from "@tauri-apps/api/core";
-import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { open } from "@tauri-apps/plugin-dialog";
-import { useI18n } from "vue-i18n";
-import HamsterLoader from "../ui/HamsterLoader.vue";
-import ImageCard from "../ui/ImageCard.vue";
-import DeleteConfirmModal from "../ui/DeleteConfirmModal.vue";
+import { ref, computed, onBeforeUnmount } from 'vue';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { open } from '@tauri-apps/plugin-dialog';
+import { useI18n } from 'vue-i18n';
+import HamsterLoader from '../components/ui/HamsterLoader.vue';
+import ImageCard from '../components/ui/ImageCard.vue';
+import DeleteConfirmModal from '../components/ui/DeleteConfirmModal.vue';
 
 interface DuplicateGroup {
   tag: string;
@@ -88,7 +88,7 @@ const busy = ref(false);
 const progress = ref(0);
 const eta = ref(0);
 const marked = ref<string[]>([]);
-const modes = ref<string[]>(["hash", "dhash"]);
+const modes = ref<string[]>(['hash', 'dhash']);
 const showConfirm = ref(false);
 const cancelled = ref(false);
 const markedCount = computed(() => marked.value.length);
@@ -103,11 +103,11 @@ function tagText(tag: string) {
 
 function recordDecision(tag: string, path: string, value: string) {
   let del: boolean | null;
-  if (value === "keep") del = false;
-  else if (value === "delete") del = true;
+  if (value === 'keep') del = false;
+  else if (value === 'delete') del = true;
   else del = null;
-  invoke("record_decision", { tag, path, delete: del });
-  if (value === "delete") {
+  invoke('record_decision', { tag, path, delete: del });
+  if (value === 'delete') {
     if (!marked.value.includes(path)) marked.value.push(path);
   } else {
     const idx = marked.value.indexOf(path);
@@ -125,12 +125,12 @@ async function scanFolder(path: string) {
     unlisten();
     unlisten = null;
   }
-  unlisten = await listen<DuplicateProgress>("duplicate_progress", (e) => {
+  unlisten = await listen<DuplicateProgress>('duplicate_progress', (e) => {
     progress.value = e.payload.progress;
     eta.value = e.payload.eta_seconds;
   });
   try {
-    const results = await invoke<DuplicateGroup[]>("scan_folder_stream_multi", {
+    const results = await invoke<DuplicateGroup[]>('scan_folder_stream_multi', {
       path,
       tags: modes.value,
     });
@@ -166,7 +166,7 @@ function deleteMarked() {
 }
 
 async function confirmDelete() {
-  await invoke("delete_files", { paths: marked.value });
+  await invoke('delete_files', { paths: marked.value });
   showConfirm.value = false;
   duplicates.value = duplicates.value
     .map((g) => ({
@@ -183,7 +183,7 @@ function cancelDelete() {
 
 function cancelScan() {
   cancelled.value = true;
-  invoke("cancel_scan");
+  invoke('cancel_scan');
   if (unlisten) {
     unlisten();
     unlisten = null;
@@ -193,7 +193,7 @@ function cancelScan() {
 
 onBeforeUnmount(() => {
   if (unlisten) unlisten();
-  invoke("cancel_scan");
+  invoke('cancel_scan');
 });
 </script>
 

--- a/src/views/Import.vue
+++ b/src/views/Import.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from "vue";
-import { useSettingsStore } from "../../stores/settings";
-import { open } from "@tauri-apps/plugin-dialog";
-import { invoke } from "@tauri-apps/api/core";
+import { ref, onMounted, onUnmounted } from 'vue';
+import { useSettingsStore } from '../stores/settings';
+import { open } from '@tauri-apps/plugin-dialog';
+import { invoke } from '@tauri-apps/api/core';
 
-import DestinationSelector from "../ui/DestinationSelector.vue";
-import DeviceCard from "../ui/DeviceCard.vue";
+import DestinationSelector from '../components/ui/DestinationSelector.vue';
+import DeviceCard from '../components/ui/DeviceCard.vue';
 
 interface Device {
   name: string;
@@ -34,7 +34,7 @@ async function chooseDest() {
 }
 
 async function loadDevices() {
-  devices.value = await invoke<Device[]>("list_external_devices");
+  devices.value = await invoke<Device[]>('list_external_devices');
   scheduleNext();
 }
 
@@ -48,7 +48,7 @@ async function copyDevice(path: string) {
   if (!settings.importDestination) return;
   busyPath.value = path;
   try {
-    await invoke("import_device", {
+    await invoke('import_device', {
       devicePath: path,
       destPath: settings.importDestination,
     });
@@ -58,7 +58,7 @@ async function copyDevice(path: string) {
 }
 
 function formatSize(bytes: number) {
-  const units = ["B", "KB", "MB", "GB", "TB"];
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
   let size = bytes,
     i = 0;
   while (size >= 1024 && i < units.length - 1) {
@@ -82,9 +82,9 @@ function formatSize(bytes: number) {
     <!-- Geräte-Liste -->
     <section>
       <header class="section-header">
-        <h2>{{ $t("import.devices") }}</h2>
+        <h2>{{ $t('import.devices') }}</h2>
         <button class="btn ghost" @click="loadDevices">
-          <span class="icon-rotate-cw" /> {{ $t("import.refresh") }}
+          <span class="icon-rotate-cw" /> {{ $t('import.refresh') }}
         </button>
       </header>
 
@@ -132,6 +132,6 @@ function formatSize(bytes: number) {
   border: 1px solid color-mix(in srgb, var(--accent-color), transparent 70%);
 }
 .icon-rotate-cw::before {
-  content: "⟳";
+  content: '⟳';
 } /* simple icon-stub */
 </style>

--- a/src/views/Sort.vue
+++ b/src/views/Sort.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { ref } from "vue";
-import { open } from "@tauri-apps/plugin-dialog";
-import { invoke } from "@tauri-apps/api/core";
-import { useI18n } from "vue-i18n";
+import { ref } from 'vue';
+import { open } from '@tauri-apps/plugin-dialog';
+import { invoke } from '@tauri-apps/api/core';
+import { useI18n } from 'vue-i18n';
 
-import DestinationSelector from "../ui/DestinationSelector.vue";
-import Thumbnail from "../ui/Thumbnail.vue";
+import DestinationSelector from '../components/ui/DestinationSelector.vue';
+import Thumbnail from '../components/ui/Thumbnail.vue';
 
 const { t } = useI18n();
 const srcPath = ref<string | null>(null);
@@ -22,14 +22,14 @@ async function chooseSource() {
 
 async function loadImages() {
   if (!srcPath.value) return;
-  images.value = await invoke<string[]>("find_images", { path: srcPath.value });
+  images.value = await invoke<string[]>('find_images', { path: srcPath.value });
 }
 
 async function startSort() {
   if (!srcPath.value) return;
   busy.value = true;
   try {
-    await invoke("sort_images", { path: srcPath.value });
+    await invoke('sort_images', { path: srcPath.value });
     await loadImages();
   } finally {
     busy.value = false;
@@ -52,7 +52,7 @@ async function startSort() {
     <p v-else class="placeholder">-</p>
 
     <button class="btn" @click="startSort" :disabled="busy || !srcPath">
-      {{ busy ? "…" : t("sort.start") }}
+      {{ busy ? '…' : t('sort.start') }}
     </button>
   </div>
 </template>

--- a/src/views/TrainingData.vue
+++ b/src/views/TrainingData.vue
@@ -1,20 +1,20 @@
 <script setup lang="ts">
-import { ref } from "vue";
-import { save } from "@tauri-apps/plugin-dialog";
-import { invoke } from "@tauri-apps/api/core";
-import { useI18n } from "vue-i18n";
+import { ref } from 'vue';
+import { save } from '@tauri-apps/plugin-dialog';
+import { invoke } from '@tauri-apps/api/core';
+import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
 const busy = ref(false);
 
 async function exportFile() {
   const selected = await save({
-    filters: [{ name: "JSON", extensions: ["json"] }],
+    filters: [{ name: 'JSON', extensions: ['json'] }],
   });
   if (!selected) return;
   busy.value = true;
   try {
-    await invoke("export_training", { path: selected });
+    await invoke('export_training', { path: selected });
   } finally {
     busy.value = false;
   }
@@ -24,7 +24,7 @@ async function exportFile() {
 <template>
   <div class="view">
     <button @click="exportFile" :disabled="busy">
-      {{ busy ? "…" : t("training.export") }}
+      {{ busy ? '…' : t('training.export') }}
     </button>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- reorganize frontend by moving page components into `src/views`
- update router imports
- fix relative paths inside moved views

## Testing
- `bun x prettier --write src/router/index.ts src/views/Blackhole.vue src/views/Duplicate.vue src/views/Import.vue src/views/Sort.vue src/views/TrainingData.vue`
- `bun run tauri dev` *(fails: `gobject-sys` missing `gobject-2.0`)*

------
https://chatgpt.com/codex/tasks/task_e_6877859474c48329a3472a4c7f143726