### PR TITLE
Improve marked card highlight

### DIFF
--- a/src/components/ui/ImageCard.vue
+++ b/src/components/ui/ImageCard.vue
@@ -84,6 +84,12 @@ onMounted(async () => {
   color: white;
 }
 .image-card.marked {
-  outline: 2px solid red;
+  outline: 2px solid var(--md-sys-color-primary, var(--accent-color));
+  box-shadow: 0 2px 6px
+    color-mix(
+      in srgb,
+      var(--md-sys-color-primary, var(--accent-color)),
+      transparent 50%
+    );
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -9,6 +9,7 @@
   --card-bg: rgba(255, 255, 255, 0.7);
   --border-color: rgba(0, 0, 0, 0.08);
   --accent-color: #4b8dff; /* neues Blau */
+  --md-sys-color-primary: var(--accent-color);
 
   /* Effekte */
   --radius-lg: 16px;
@@ -17,13 +18,14 @@
 }
 
 /* Dark Mode */
-[data-theme="dark"] {
+[data-theme='dark'] {
   --bg-gradient-start: #0d1224;
   --bg-gradient-end: #1b2036;
   --text-color: #f5f5f7;
   --card-bg: rgba(44, 44, 46, 0.6);
   --border-color: rgba(255, 255, 255, 0.1);
   --accent-color: #4b8dff;
+  --md-sys-color-primary: var(--accent-color);
   --shadow-soft: 0 6px 24px rgba(0, 0, 0, 0.4);
 }
 
@@ -39,8 +41,8 @@ body {
   );
   color: var(--text-color);
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-    Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+    Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   margin: 0;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add `--md-sys-color-primary` variable mapped to accent color
- highlight `.image-card.marked` with the Material primary color

## Testing
- `bun run tauri dev` *(build started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6877e91925648329b2ce8850ecc9675f