### PR TITLE
Implement grouped duplicate card

### DIFF
--- a/src/components/ui/DuplicateGroupCard.vue
+++ b/src/components/ui/DuplicateGroupCard.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="duplicate-card">
+    <Thumbnail :path="group.paths[0]" class="preview" />
+    <div class="path-list">
+      <div
+        v-for="p in group.paths"
+        :key="p"
+        class="path-row"
+        :class="{ marked: marked.includes(p) }"
+      >
+        <span class="path">{{ p }}</span>
+        <button @click="toggle(p)">
+          {{ marked.includes(p) ? keepText : deleteText }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import Thumbnail from './Thumbnail.vue';
+
+const props = defineProps<{
+  group: { tag: string; hash: string; paths: string[] };
+  marked: string[];
+  deleteText: string;
+  keepText: string;
+}>();
+
+const emit = defineEmits<{ decision: [path: string, value: string] }>();
+
+function toggle(path: string) {
+  if (props.marked.includes(path)) emit('decision', path, 'keep');
+  else emit('decision', path, 'delete');
+}
+</script>
+
+<style scoped>
+.duplicate-card {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+.preview {
+  flex-shrink: 0;
+}
+.path-list {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.path-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.path-row .path {
+  flex: 1;
+  word-break: break-word;
+  font-size: 0.8rem;
+}
+.path-row button {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  background: red;
+  color: white;
+}
+.path-row.marked .path {
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+</style>

--- a/src/views/Duplicate.vue
+++ b/src/views/Duplicate.vue
@@ -30,17 +30,15 @@
     <div v-if="duplicates.length" class="duplicate-list">
       <div v-for="d in duplicates" :key="d.hash" class="duplicate-group">
         <h3>{{ tagText(d.tag) }}</h3>
-        <div class="image-pair">
-          <ImageCard
-            v-for="p in d.paths"
-            :key="p"
-            :path="p"
-            :marked="marked.includes(p)"
-            :keep-text="t('common.keep')"
-            :delete-text="t('common.delete')"
-            @decision="(v: string) => recordDecision(d.tag, p, v)"
-          />
-        </div>
+        <DuplicateGroupCard
+          :group="d"
+          :marked="marked"
+          :delete-text="t('common.delete')"
+          :keep-text="t('common.keep')"
+          @decision="
+            (path: string, v: string) => recordDecision(d.tag, path, v)
+          "
+        />
       </div>
     </div>
 
@@ -69,7 +67,7 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { open } from '@tauri-apps/plugin-dialog';
 import { useI18n } from 'vue-i18n';
 import HamsterLoader from '../components/ui/HamsterLoader.vue';
-import ImageCard from '../components/ui/ImageCard.vue';
+import DuplicateGroupCard from '../components/ui/DuplicateGroupCard.vue';
 import DeleteConfirmModal from '../components/ui/DeleteConfirmModal.vue';
 
 interface DuplicateGroup {
@@ -242,12 +240,6 @@ onBeforeUnmount(() => {
 .duplicate-group h3 {
   font-size: 1rem;
   margin-bottom: 0.5rem;
-}
-
-.image-pair {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
 }
 
 .delete-bar {


### PR DESCRIPTION
## Summary
- add `DuplicateGroupCard` component showing one preview with path list
- update duplicate view to use the new component

## Testing
- `bun run tauri dev` *(failed: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877ff3f5a30832988724b50324125ec