### PR TITLE
Add duplicate destination selector

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,16 +1,28 @@
-import { defineStore } from "pinia";
-import { ref, watch } from "vue";
+import { defineStore } from 'pinia';
+import { ref, watch } from 'vue';
 
-export const useSettingsStore = defineStore("settings", () => {
+export const useSettingsStore = defineStore('settings', () => {
   const importDestination = ref<string | null>(
-    localStorage.getItem("importDest"),
+    localStorage.getItem('importDest'),
+  );
+
+  const duplicateDestination = ref<string | null>(
+    localStorage.getItem('duplicateDest'),
   );
 
   watch(importDestination, (val) => {
     if (val) {
-      localStorage.setItem("importDest", val);
+      localStorage.setItem('importDest', val);
     } else {
-      localStorage.removeItem("importDest");
+      localStorage.removeItem('importDest');
+    }
+  });
+
+  watch(duplicateDestination, (val) => {
+    if (val) {
+      localStorage.setItem('duplicateDest', val);
+    } else {
+      localStorage.removeItem('duplicateDest');
     }
   });
 
@@ -18,5 +30,14 @@ export const useSettingsStore = defineStore("settings", () => {
     importDestination.value = path;
   }
 
-  return { importDestination, setImportDestination };
+  function setDuplicateDestination(path: string | null) {
+    duplicateDestination.value = path;
+  }
+
+  return {
+    importDestination,
+    setImportDestination,
+    duplicateDestination,
+    setDuplicateDestination,
+  };
 });

--- a/src/views/Duplicate.vue
+++ b/src/views/Duplicate.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="view" @drop.prevent="handleDrop" @dragover.prevent>
+    <DestinationSelector
+      :path="settings.duplicateDestination"
+      :label="t('import.destination')"
+      :choose-text="t('import.choose')"
+      @choose="chooseDest"
+    />
     <div class="mode-picker">
       <label>
         <input type="checkbox" value="hash" v-model="modes" />
@@ -67,6 +73,8 @@ import { useI18n } from 'vue-i18n';
 import HamsterLoader from '../components/ui/HamsterLoader.vue';
 import DuplicateGroupCard from '../components/ui/DuplicateGroupCard.vue';
 import DeleteConfirmModal from '../components/ui/DeleteConfirmModal.vue';
+import DestinationSelector from '../components/ui/DestinationSelector.vue';
+import { useSettingsStore } from '../stores/settings';
 
 interface DuplicateGroup {
   tag: string;
@@ -100,6 +108,7 @@ const cancelled = ref(false);
 const markedCount = computed(() => marked.value.length);
 let unlisten: UnlistenFn | null = null;
 const { t } = useI18n();
+const settings = useSettingsStore();
 
 function tagText(tag: string) {
   const key = `duplicate.tags.${tag}`;
@@ -170,6 +179,13 @@ async function openDialog() {
   if (selected) {
     scanFolder(selected as string);
   }
+}
+
+async function chooseDest() {
+  const selected = await open({ directory: true, multiple: false });
+  if (!selected) return;
+  const path = Array.isArray(selected) ? selected[0] : selected;
+  settings.setDuplicateDestination(path);
 }
 
 function deleteMarked() {


### PR DESCRIPTION
## Summary
- extend settings store with `duplicateDestination`
- show `DestinationSelector` in Duplicate view using the new setting

## Testing
- `bun run tauri dev` *(fails: interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_68781715296c832980dbd7cd80c26de8