### PR TITLE
Fix file age calculation error

### DIFF
--- a/src-tauri/src/duplicate/scan_folder_stream_multi.rs
+++ b/src-tauri/src/duplicate/scan_folder_stream_multi.rs
@@ -44,7 +44,11 @@ fn blake3_mmap(path: &Path) -> Result<String, String> {
 fn file_age_seconds(path: &str) -> u64 {
     std::fs::metadata(path)
         .and_then(|m| m.modified())
-        .and_then(|t| std::time::SystemTime::now().duration_since(t))
+        .and_then(|t| {
+            std::time::SystemTime::now()
+                .duration_since(t)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        })
         .map(|d| d.as_secs())
         .unwrap_or(0)
 }


### PR DESCRIPTION
## Summary
- handle `SystemTime` errors in `file_age_seconds`

## Testing
- `bun run tauri dev` *(fails: Failed to initialize GTK)*

------
https://chatgpt.com/codex/tasks/task_e_68781b878df08329807f1bf0572290d9