### PR TITLE
Update duplicate scan workflow

### DIFF
--- a/src/views/Duplicate.vue
+++ b/src/views/Duplicate.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="view" @drop.prevent="handleDrop" @dragover.prevent>
+  <div class="view">
     <DestinationSelector
       :path="settings.duplicateDestination"
       :label="t('import.destination')"
@@ -16,14 +16,14 @@
         {{ t('duplicate.modes.perceptual') }}
       </label>
     </div>
-    <div
-      class="dropzone"
-      v-if="!duplicates.length && !busy"
-      @click="openDialog"
+    <button
+      v-if="!busy"
+      class="btn"
+      @click="startScan"
+      :disabled="!settings.duplicateDestination"
     >
-      <p>{{ t('duplicate.dragDropInstruction') }}</p>
-      <small>{{ t('duplicate.orClickToSelect') }}</small>
-    </div>
+      {{ busy ? t('duplicate.scanning') : t('blackhole.scan') }}
+    </button>
 
     <HamsterLoader v-if="busy" />
     <div v-if="busy" class="status">
@@ -157,28 +157,9 @@ async function scanFolder(path: string) {
   }
 }
 
-interface DropFile extends File {
-  /**
-   * Tauri injects a `path` property into the dropped file object which
-   * contains the filesystem path on all platforms. This is not part of the
-   * standard `File` interface, so we mark it as optional.
-   */
-  path?: string;
-}
-
-function handleDrop(event: DragEvent) {
-  const files = event.dataTransfer?.files;
-  if (!files || !files.length) return;
-
-  const file = files[0] as DropFile;
-  const path = file.path ?? file.webkitRelativePath;
-  if (path) scanFolder(path);
-}
-
-async function openDialog() {
-  const selected = await open({ directory: true, multiple: false });
-  if (selected) {
-    scanFolder(selected as string);
+function startScan() {
+  if (settings.duplicateDestination) {
+    scanFolder(settings.duplicateDestination);
   }
 }
 
@@ -235,21 +216,6 @@ onBeforeUnmount(() => {
 <style scoped>
 .view {
   padding: 1rem;
-}
-
-.dropzone {
-  border: 2px dashed var(--border-color);
-  padding: 2rem;
-  text-align: center;
-  border-radius: 1rem;
-  background: var(--card-bg);
-  color: var(--text-muted);
-  margin-top: 2rem;
-  cursor: pointer;
-  transition: background 0.2s;
-}
-.dropzone:hover {
-  background: var(--hover-bg, rgba(0, 0, 0, 0.05));
 }
 
 .status {


### PR DESCRIPTION
## Summary
- swap duplicate drag-and-drop zone for a normal scan button
- disable scan when no destination is chosen

## Testing
- `bun run tauri dev` *(fails: Failed to initialize GTK)*

------
https://chatgpt.com/codex/tasks/task_e_68781e90a5f883298fcc26112a41e6ab