### PR TITLE
Add tooltips for duplicate modes

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -14,7 +14,9 @@
     "tags": {
       "hash": "Absolut identisch",
       "dhash": "Ähnlich"
-    }
+    },
+    "exactTooltip": "Findet nur Dateien, die komplett identisch sind.",
+    "perceptualTooltip": "Findet auch Bilder, die sich ähnlich sehen, selbst wenn die Dateien unterschiedlich sind."
   },
   "common": {
     "keep": "Behalten",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -14,7 +14,9 @@
     "tags": {
       "hash": "Exact match",
       "dhash": "Perceptual match"
-    }
+    },
+    "exactTooltip": "Only find files that are completely identical.",
+    "perceptualTooltip": "Also detect images that look the same even if the files are different."
   },
   "common": {
     "keep": "keep",

--- a/src/views/Duplicate.vue
+++ b/src/views/Duplicate.vue
@@ -7,11 +7,11 @@
       @choose="chooseDest"
     />
     <div class="mode-picker">
-      <label>
+      <label :title="t('duplicate.exactTooltip')">
         <input type="checkbox" value="hash" v-model="modes" />
         {{ t('duplicate.modes.exact') }}
       </label>
-      <label>
+      <label :title="t('duplicate.perceptualTooltip')">
         <input type="checkbox" value="dhash" v-model="modes" />
         {{ t('duplicate.modes.perceptual') }}
       </label>


### PR DESCRIPTION
## Summary
- explain exact and perceptual duplicate detection with tooltips
- update English and German locales

Build run with `bun run tauri dev` succeeded until GTK failed to launch in this environment.


------
https://chatgpt.com/codex/tasks/task_e_68781edb6674832980a0e75aa6c99c94