### PR TITLE
Add size data for duplicate groups

### DIFF
--- a/src-tauri/src/duplicate/scan_folder_stream_multi.rs
+++ b/src-tauri/src/duplicate/scan_folder_stream_multi.rs
@@ -20,6 +20,8 @@ pub struct DuplicateGroup {
     pub tag: String,
     /// Content hash of all files in this group.
     pub hash: String,
+    /// Size of each file in bytes.
+    pub size: u64,
     /// Paths of the duplicate files.
     pub paths: Vec<String>,
     /// Age of each file in seconds since last modification.
@@ -150,7 +152,8 @@ pub fn heavy_scan_multi_stream(
                     .iter()
                     .map(|p| file_age_seconds(p))
                     .collect();
-                result.push(DuplicateGroup { tag: "hash".into(), hash, paths, ages });
+                let size = std::fs::metadata(&paths[0]).map(|m| m.len()).unwrap_or(0);
+                result.push(DuplicateGroup { tag: "hash".into(), hash, size, paths, ages });
             }
         }
     }
@@ -162,7 +165,8 @@ pub fn heavy_scan_multi_stream(
                     .iter()
                     .map(|p| file_age_seconds(p))
                     .collect();
-                result.push(DuplicateGroup { tag: "dhash".into(), hash, paths, ages });
+                let size = std::fs::metadata(&paths[0]).map(|m| m.len()).unwrap_or(0);
+                result.push(DuplicateGroup { tag: "dhash".into(), hash, size, paths, ages });
             }
         }
     }

--- a/src/components/ui/DuplicateGroupCard.vue
+++ b/src/components/ui/DuplicateGroupCard.vue
@@ -23,7 +23,13 @@ import { computed } from 'vue';
 import Thumbnail from './Thumbnail.vue';
 
 const props = defineProps<{
-  group: { tag: string; hash: string; paths: string[]; ages: number[] };
+  group: {
+    tag: string;
+    hash: string;
+    size: number;
+    paths: string[];
+    ages: number[];
+  };
   marked: string[];
   deleteText: string;
   keepText: string;

--- a/src/views/Duplicate.vue
+++ b/src/views/Duplicate.vue
@@ -35,7 +35,10 @@
 
     <div v-if="duplicates.length" class="duplicate-list">
       <div v-for="d in duplicates" :key="d.hash" class="duplicate-group">
-        <h3>{{ tagText(d.tag) }}</h3>
+        <h3>
+          {{ tagText(d.tag) }}
+          <small>{{ formatSize(d.size) }}</small>
+        </h3>
         <DuplicateGroupCard
           :group="d"
           :marked="marked"
@@ -79,6 +82,7 @@ import { useSettingsStore } from '../stores/settings';
 interface DuplicateGroup {
   tag: string;
   hash: string;
+  size: number;
   paths: string[];
   ages: number[];
 }
@@ -115,6 +119,17 @@ function tagText(tag: string) {
   const key = `duplicate.tags.${tag}`;
   const result = t(key);
   return result === key ? tag : result;
+}
+
+function formatSize(bytes: number) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = bytes,
+    i = 0;
+  while (size >= 1024 && i < units.length - 1) {
+    size /= 1024;
+    i++;
+  }
+  return `${size.toFixed(1)} ${units[i]}`;
 }
 
 function updateMarked(path: string, value: string) {


### PR DESCRIPTION
## Summary
- include file size in DuplicateGroup from the backend
- expose size in frontend and display it in duplicate list

## Testing
- `bun run format`
- `bun run tauri dev` *(build started and Vite server ran)*

------
https://chatgpt.com/codex/tasks/task_e_6878203b2ad48329aa6c2dd033a22f47