### PR TITLE
Add automatic duplicate marking

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -4,6 +4,7 @@
     "choose": "Ordner auswählen & scannen",
     "scanning": "Scanne…",
     "deleteMarked": "Markierte löschen",
+    "autoMark": "Automatisch markieren",
     "confirmDelete": "Möchtest du wirklich {count} Dateien löschen?",
     "dragDropInstruction": "Ziehe einen Ordner hierher",
     "orClickToSelect": "oder klicke hier, um einen Ordner auszuwählen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,7 @@
     "choose": "Choose folder & scan",
     "scanning": "Scanning…",
     "deleteMarked": "Delete marked",
+    "autoMark": "Auto mark",
     "confirmDelete": "Are you sure you want to delete {count} files?",
     "dragDropInstruction": "Drag and drop",
     "orClickToSelect": "or click",

--- a/src/views/Duplicate.vue
+++ b/src/views/Duplicate.vue
@@ -46,6 +46,12 @@
       </div>
     </div>
 
+    <div v-if="duplicates.length" class="auto-mark-bar">
+      <button class="ghost auto-mark-button" @click="autoMark">
+        {{ t('duplicate.autoMark') }}
+      </button>
+    </div>
+
     <div v-if="markedCount" class="delete-bar">
       <button class="delete-button" @click="deleteMarked">
         {{ t('duplicate.deleteMarked') }}
@@ -124,6 +130,22 @@ function updateMarked(path: string, value: string) {
     const idx = marked.value.indexOf(path);
     if (idx !== -1) marked.value.splice(idx, 1);
   }
+}
+
+function autoMark() {
+  duplicates.value.forEach((g) => {
+    if (g.paths.length <= 1) return;
+    const maxAge = Math.max(...g.ages);
+    const keepIdx = g.ages.indexOf(maxAge);
+    g.paths.forEach((p, idx) => {
+      if (idx === keepIdx) {
+        const i = marked.value.indexOf(p);
+        if (i !== -1) marked.value.splice(i, 1);
+      } else if (!marked.value.includes(p)) {
+        marked.value.push(p);
+      }
+    });
+  });
 }
 
 async function scanFolder(path: string) {
@@ -267,6 +289,16 @@ onBeforeUnmount(() => {
 .duplicate-group h3 {
   font-size: 1rem;
   margin-bottom: 0.5rem;
+}
+
+.auto-mark-bar {
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.auto-mark-button {
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
 }
 
 .delete-bar {


### PR DESCRIPTION
## Summary
- add an "Automatisch markieren" button in duplicate view
- mark all but the oldest file per hash when clicking the button
- add translations for the button text

Build ran with `bun run tauri dev` to ensure compilation.


------
https://chatgpt.com/codex/tasks/task_e_687820a2f37883299cb2edc77383f1ee