### PR TITLE
Fix duplicate list reset on rescan

### DIFF
--- a/src/views/Duplicate.vue
+++ b/src/views/Duplicate.vue
@@ -165,6 +165,7 @@ function autoMark() {
 
 async function scanFolder(path: string) {
   busy.value = true;
+  duplicates.value = [];
   progress.value = 0;
   eta.value = 0;
   marked.value = [];


### PR DESCRIPTION
## Summary
- clear duplicates list when starting a new scan

## Testing
- `bun run format`
- `bun run tauri dev` *(stopped after startup)*

------
https://chatgpt.com/codex/tasks/task_e_6878941332f483298f33ba587d3f7018