### PR TITLE
Fix PerceptualDHash mapping handling

### DIFF
--- a/src/components/ui/DuplicateGroupCard.vue
+++ b/src/components/ui/DuplicateGroupCard.vue
@@ -24,7 +24,7 @@ import Thumbnail from './Thumbnail.vue';
 
 const props = defineProps<{
   group: {
-    method: string;
+    method: unknown;
     files: {
       path: string;
       age: number;

--- a/src/views/Duplicate.vue
+++ b/src/views/Duplicate.vue
@@ -98,7 +98,7 @@ interface FileInfo {
 }
 
 interface DuplicateGroup {
-  method: string;
+  method: unknown;
   files: FileInfo[];
 }
 
@@ -127,14 +127,20 @@ let unlisten: UnlistenFn | null = null;
 const { t } = useI18n();
 const settings = useSettingsStore();
 
-function tagText(tag: string) {
+function tagText(tag: unknown) {
+  let name: string;
+  if (typeof tag === 'object' && tag !== null) {
+    name = Object.keys(tag)[0];
+  } else {
+    name = String(tag);
+  }
   const map: Record<string, string> = {
     ByteHash: 'hash',
     PerceptualDHash: 'dhash',
   };
-  const key = `duplicate.tags.${map[tag] ?? tag}`;
+  const key = `duplicate.tags.${map[name] ?? name}`;
   const result = t(key);
-  return result === key ? tag : result;
+  return result === key ? name : result;
 }
 
 function formatSize(bytes: number) {


### PR DESCRIPTION
## Summary
- handle enum objects returned from backend when displaying duplicate groups
- adjust types for new structure

## Testing
- `bun run tauri dev` *(fails: Failed to initialize GTK)*

------
https://chatgpt.com/codex/tasks/task_e_687c028ca47c8329b3507fa5c0f729bc