### PR TITLE
Add allowed extension config

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -51,5 +51,9 @@
     "copy": "Kopieren",
     "cut": "Ausschneiden",
     "files": "Dateien"
+  },
+  "config": {
+    "title": "Konfiguration",
+    "allowedExtensions": "Erlaubte Endungen"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -51,5 +51,9 @@
     "copy": "Copy",
     "cut": "Cut",
     "files": "files"
+  },
+  "config": {
+    "title": "Config",
+    "allowedExtensions": "Allowed extensions"
   }
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,6 +5,7 @@ import ImportView from '../views/Import.vue';
 import SortView from '../views/Sort.vue';
 import Blackhole from '../views/Blackhole.vue';
 import Home from '../views/Home.vue';
+import ConfigView from '../views/Config.vue';
 
 const routes: Array<RouteRecordRaw> = [
   { path: '/', name: 'home', component: Home },
@@ -12,6 +13,7 @@ const routes: Array<RouteRecordRaw> = [
   { path: '/import', name: 'import', component: ImportView },
   { path: '/sort', name: 'sort', component: SortView },
   { path: '/blackhole', name: 'blackhole', component: Blackhole },
+  { path: '/config', name: 'config', component: ConfigView },
 ];
 
 const router = createRouter({

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -10,6 +10,33 @@ export const useSettingsStore = defineStore('settings', () => {
     localStorage.getItem('duplicateDest'),
   );
 
+  const allExtensions = [
+    'jpg',
+    'jpeg',
+    'png',
+    'gif',
+    'bmp',
+    'tif',
+    'tiff',
+    'webp',
+    'heic',
+    'heif',
+    'raw',
+    'arw',
+    'dng',
+    'cr2',
+    'nef',
+    'pef',
+    'rw2',
+    'sr2',
+  ];
+
+  const allowedExtensions = ref<string[]>(
+    JSON.parse(localStorage.getItem('allowedExtensions') ?? 'null') ?? [
+      ...allExtensions,
+    ],
+  );
+
   watch(importDestination, (val) => {
     if (val) {
       localStorage.setItem('importDest', val);
@@ -26,6 +53,14 @@ export const useSettingsStore = defineStore('settings', () => {
     }
   });
 
+  watch(
+    allowedExtensions,
+    (val) => {
+      localStorage.setItem('allowedExtensions', JSON.stringify(val));
+    },
+    { deep: true },
+  );
+
   function setImportDestination(path: string | null) {
     importDestination.value = path;
   }
@@ -34,10 +69,17 @@ export const useSettingsStore = defineStore('settings', () => {
     duplicateDestination.value = path;
   }
 
+  function setAllowedExtensions(exts: string[]) {
+    allowedExtensions.value = exts;
+  }
+
   return {
     importDestination,
     setImportDestination,
     duplicateDestination,
     setDuplicateDestination,
+    allExtensions,
+    allowedExtensions,
+    setAllowedExtensions,
   };
 });

--- a/src/views/Config.vue
+++ b/src/views/Config.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { useSettingsStore } from '../stores/settings';
+import { useI18n } from 'vue-i18n';
+
+const settings = useSettingsStore();
+const { t } = useI18n();
+
+function toggle(ext: string) {
+  const current = settings.allowedExtensions.slice();
+  if (current.includes(ext)) {
+    settings.setAllowedExtensions(current.filter((e) => e !== ext));
+  } else {
+    current.push(ext);
+    settings.setAllowedExtensions(current);
+  }
+}
+</script>
+
+<template>
+  <div class="view config-view">
+    <h2>{{ t('config.allowedExtensions') }}</h2>
+    <div class="ext-grid">
+      <label v-for="ext in settings.allExtensions" :key="ext">
+        <input
+          type="checkbox"
+          :checked="settings.allowedExtensions.includes(ext)"
+          @change="toggle(ext)"
+        />
+        {{ ext }}
+      </label>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.config-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ext-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 0.5rem;
+}
+
+label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -85,6 +85,32 @@ const { t } = useI18n();
         </svg>
         {{ t('blackhole.title') }}
       </router-link>
+      <router-link class="card" to="/config">
+        <svg
+          class="card-icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 15.5C13.933 15.5 15.5 13.933 15.5 12C15.5 10.067 13.933 8.5 12 8.5C10.067 8.5 8.5 10.067 8.5 12C8.5 13.933 10.067 15.5 12 15.5Z"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M19.4 15A1.65 1.65 0 0 0 21 13.35C20.69 12.24 20.17 11.18 19.45 10.2C19.17 9.8 19.2 9.25 19.55 8.9L20.85 7.6C21.1 7.35 21.1 6.95 20.85 6.7L17.3 3.15C17.05 2.9 16.65 2.9 16.4 3.15L15.1 4.45C14.75 4.8 14.2 4.83 13.8 4.55C12.82 3.83 11.76 3.31 10.65 3C9 3.6 8.35 5.2 9.95 6.8C10.15 7 10.2 7.3 10.1 7.55L8.5 12C8.55 12.45 8.7 12.95 9 13.45C9.5 14.45 10.4 15.35 11.4 15.85C11.9 16.15 12.4 16.3 12.85 16.35L17.3 14.75C17.55 14.65 17.85 14.7 18.05 14.9C19.65 16.5 21.25 15.85 21.85 14.2C21.54 13.09 21.02 12.03 20.3 11.05"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        {{ t('config.title') }}
+      </router-link>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- create new config page to toggle allowed extensions
- store custom extensions in settings store and persist to localStorage
- add route and home link to config
- update translations

## Testing
- `npm run tauri-build` *(fails: protocol: http response missing version)*

------
https://chatgpt.com/codex/tasks/task_e_6882b5b46c788329beb91eaa12a21119