### PR TITLE
Fix missing translations

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -11,14 +11,21 @@
     "orClickToSelect": "oder klicke hier, um einen Ordner auszuwählen",
     "modes": {
       "exact": "Exakt",
-      "perceptual": "Perzeptuell"
+      "perceptual": "Perzeptuell",
+      "title": "Erkennungsmodi"
     },
     "tags": {
       "hash": "Absolut identisch",
       "dhash": "Ähnlich"
     },
     "exactTooltip": "Findet nur Dateien, die komplett identisch sind.",
-    "perceptualTooltip": "Findet auch Bilder, die sich ähnlich sehen, selbst wenn die Dateien unterschiedlich sind."
+    "perceptualTooltip": "Findet auch Bilder, die sich ähnlich sehen, selbst wenn die Dateien unterschiedlich sind.",
+    "subtitle": "Doppelte Bilder finden",
+    "destinationLabel": "Zu scannender Ordner:",
+    "resultsTitle": "{count} Duplikatgruppen gefunden",
+    "advancedOptions": "Erweiterte Optionen",
+    "sensitivityLabel": "Empfindlichkeit:",
+    "sensitivityTooltip": "Höhere Werte finden mehr Unterschiede"
   },
   "common": {
     "keep": "Behalten",
@@ -34,8 +41,8 @@
     "devices": "Externe Geräte",
     "refresh": "Aktualisieren",
     "copy": "Bilder kopieren",
-    "no_devices_found": "Kein Geräte gefunden",
-    "connect_device_prompt": ""
+    "no_devices_found": "Kein Gerät gefunden",
+    "connect_device_prompt": "Bitte ein Gerät verbinden und auf Aktualisieren klicken."
   },
   "home": {
     "duplicate": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,14 +11,21 @@
     "orClickToSelect": "or click",
     "modes": {
       "exact": "Exact",
-      "perceptual": "Perceptual"
+      "perceptual": "Perceptual",
+      "title": "Detection modes"
     },
     "tags": {
       "hash": "Exact match",
       "dhash": "Perceptual match"
     },
     "exactTooltip": "Only find files that are completely identical.",
-    "perceptualTooltip": "Also detect images that look the same even if the files are different."
+    "perceptualTooltip": "Also detect images that look the same even if the files are different.",
+    "subtitle": "Find duplicate images",
+    "destinationLabel": "Folder to scan:",
+    "resultsTitle": "{count} duplicate groups found",
+    "advancedOptions": "Advanced options",
+    "sensitivityLabel": "Sensitivity:",
+    "sensitivityTooltip": "Higher values find more differences"
   },
   "common": {
     "keep": "keep",
@@ -35,16 +42,16 @@
     "refresh": "Refresh",
     "copy": "Copy images",
     "no_devices_found": "No Devices found",
-    "connect_device_prompt": ""
+    "connect_device_prompt": "Please connect a device and click refresh."
   },
   "home": {
     "duplicate": {
-      "title": "Duplikate finden",
-      "description": "Scannen Sie Ordner, um doppelte Bilder zu finden und Speicherplatz freizugeben."
+      "title": "Find duplicates",
+      "description": "Scan folders to find duplicate images and free up space."
     },
     "import": {
-      "title": "Bilder importieren",
-      "description": "Fügen Sie neue Bilder hinzu und organisieren Sie Ihre Sammlung. Sie können Dateien auch hierher ziehen."
+      "title": "Import images",
+      "description": "Add new images and organize your collection. You can also drag files here."
     }
   }
 }


### PR DESCRIPTION
## Summary
- add translation keys used by Duplicate.vue
- correct English home texts and German grammar
- fill connect-device prompt for both languages

Compilation with `npm run tauri build` failed when bundling binaries due to network issues.


------
https://chatgpt.com/codex/tasks/task_e_688a9a9151f48329aeb2cbf9c817107f