### PR TITLE
Add multiple language support

### DIFF
--- a/src/assets/flag-es.svg
+++ b/src/assets/flag-es.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="3" height="2" fill="#aa151b"/>
+  <rect y="0.5" width="3" height="1" fill="#f1bf00"/>
+</svg>

--- a/src/assets/flag-fr.svg
+++ b/src/assets/flag-fr.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="1" height="2" fill="#0055a4"/>
+  <rect x="1" width="1" height="2" fill="#fff"/>
+  <rect x="2" width="1" height="2" fill="#ef4135"/>
+</svg>

--- a/src/assets/flag-hi.svg
+++ b/src/assets/flag-hi.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="3" height="0.666" fill="#ff9933"/>
+  <rect y="0.666" width="3" height="0.666" fill="#ffffff"/>
+  <rect y="1.334" width="3" height="0.666" fill="#128807"/>
+  <circle cx="1.5" cy="1" r="0.3" fill="#000088"/>
+</svg>

--- a/src/assets/flag-ja.svg
+++ b/src/assets/flag-ja.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="3" height="2" fill="#ffffff"/>
+  <circle cx="1.5" cy="1" r="0.6" fill="#bc002d"/>
+</svg>

--- a/src/assets/flag-pt.svg
+++ b/src/assets/flag-pt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="1.2" height="2" fill="#006600"/>
+  <rect x="1.2" width="1.8" height="2" fill="#ff0000"/>
+</svg>

--- a/src/assets/flag-ru.svg
+++ b/src/assets/flag-ru.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="3" height="0.666" fill="#ffffff"/>
+  <rect y="0.666" width="3" height="0.666" fill="#0039a6"/>
+  <rect y="1.334" width="3" height="0.666" fill="#d52b1e"/>
+</svg>

--- a/src/assets/flag-zh.svg
+++ b/src/assets/flag-zh.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="3" height="2" fill="#de2910"/>
+  <polygon points="0.5,0.3 0.6,0.6 0.3,0.45 0.7,0.45 0.4,0.6" fill="#ffde00"/>
+</svg>

--- a/src/components/ui/home/AppHeader.vue
+++ b/src/components/ui/home/AppHeader.vue
@@ -7,6 +7,13 @@ import { onClickOutside } from '@vueuse/core';
 // --- Assets ---
 import flagEn from '../../../assets/flag-en.svg?url';
 import flagDe from '../../../assets/flag-de.svg?url';
+import flagEs from '../../../assets/flag-es.svg?url';
+import flagZh from '../../../assets/flag-zh.svg?url';
+import flagFr from '../../../assets/flag-fr.svg?url';
+import flagPt from '../../../assets/flag-pt.svg?url';
+import flagJa from '../../../assets/flag-ja.svg?url';
+import flagHi from '../../../assets/flag-hi.svg?url';
+import flagRu from '../../../assets/flag-ru.svg?url';
 import ThemeToggle from './ThemeToggle.vue';
 
 // --- Refs und State ---
@@ -60,6 +67,13 @@ function goBack() {
 const languages = [
   { code: 'en', icon: flagEn, name: 'English' },
   { code: 'de', icon: flagDe, name: 'Deutsch' },
+  { code: 'es', icon: flagEs, name: 'Español' },
+  { code: 'zh', icon: flagZh, name: '中文' },
+  { code: 'fr', icon: flagFr, name: 'Français' },
+  { code: 'pt', icon: flagPt, name: 'Português' },
+  { code: 'ja', icon: flagJa, name: '日本語' },
+  { code: 'hi', icon: flagHi, name: 'हिन्दी' },
+  { code: 'ru', icon: flagRu, name: 'Русский' },
 ];
 
 const currentLang = computed(
@@ -111,7 +125,11 @@ onClickOutside(langSelectElement, () => (isLangOpen.value = false));
     </div>
 
     <div class="header-right">
-      <ThemeToggle :theme="theme" @toggle="toggleTheme" :size="15"></ThemeToggle>
+      <ThemeToggle
+        :theme="theme"
+        @toggle="toggleTheme"
+        :size="15"
+      ></ThemeToggle>
       <div class="lang-select" ref="langSelectElement">
         <button
           @click="isLangOpen = !isLangOpen"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,59 @@
+{
+  "duplicate": {
+    "title": "Duplicate",
+    "choose": "Choose folder & scan",
+    "scan": "Scan",
+    "scanning": "Scanning…",
+    "deleteMarked": "Delete marked",
+    "autoMark": "Auto mark",
+    "confirmDelete": "Are you sure you want to delete {count} files?",
+    "dragDropInstruction": "Drag and drop",
+    "orClickToSelect": "or click",
+    "modes": {
+      "exact": "Exact",
+      "perceptual": "Perceptual",
+      "title": "Detection modes"
+    },
+    "tags": {
+      "hash": "Exact match",
+      "dhash": "Perceptual match"
+    },
+    "exactTooltip": "Only find files that are completely identical.",
+    "perceptualTooltip": "Also detect images that look the same even if the files are different.",
+    "subtitle": "Find duplicate images",
+    "destinationLabel": "Folder to scan:",
+    "resultsTitle": "{count} duplicate groups found",
+    "advancedOptions": "Advanced options",
+    "sensitivityLabel": "Sensitivity:",
+    "sensitivityTooltip": "Higher values find more differences"
+  },
+  "common": {
+    "keep": "keep",
+    "delete": "delete",
+    "yes": "Yes",
+    "no": "No",
+    "cancel": "Cancel"
+  },
+  "import": {
+    "title": "Import",
+    "choose": "Choose destination",
+    "destination": "Destination:",
+    "devices": "External devices",
+    "refresh": "Refresh",
+    "copy": "Copy images",
+    "no_devices_found": "No Devices found",
+    "connect_device_prompt": "Please connect a device and click refresh."
+  },
+  "home": {
+    "title": "Welcome to Image Mami",
+    "subtitle": "What would you like to do?",
+    "duplicate": {
+      "title": "Find duplicates",
+      "description": "Scan folders to find duplicate images and free up space."
+    },
+    "import": {
+      "title": "Import images",
+      "description": "Add new images and organize your collection. You can also drag files here."
+    }
+  }
+}

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,0 +1,59 @@
+{
+  "duplicate": {
+    "title": "Duplicate",
+    "choose": "Choose folder & scan",
+    "scan": "Scan",
+    "scanning": "Scanning…",
+    "deleteMarked": "Delete marked",
+    "autoMark": "Auto mark",
+    "confirmDelete": "Are you sure you want to delete {count} files?",
+    "dragDropInstruction": "Drag and drop",
+    "orClickToSelect": "or click",
+    "modes": {
+      "exact": "Exact",
+      "perceptual": "Perceptual",
+      "title": "Detection modes"
+    },
+    "tags": {
+      "hash": "Exact match",
+      "dhash": "Perceptual match"
+    },
+    "exactTooltip": "Only find files that are completely identical.",
+    "perceptualTooltip": "Also detect images that look the same even if the files are different.",
+    "subtitle": "Find duplicate images",
+    "destinationLabel": "Folder to scan:",
+    "resultsTitle": "{count} duplicate groups found",
+    "advancedOptions": "Advanced options",
+    "sensitivityLabel": "Sensitivity:",
+    "sensitivityTooltip": "Higher values find more differences"
+  },
+  "common": {
+    "keep": "keep",
+    "delete": "delete",
+    "yes": "Yes",
+    "no": "No",
+    "cancel": "Cancel"
+  },
+  "import": {
+    "title": "Import",
+    "choose": "Choose destination",
+    "destination": "Destination:",
+    "devices": "External devices",
+    "refresh": "Refresh",
+    "copy": "Copy images",
+    "no_devices_found": "No Devices found",
+    "connect_device_prompt": "Please connect a device and click refresh."
+  },
+  "home": {
+    "title": "Welcome to Image Mami",
+    "subtitle": "What would you like to do?",
+    "duplicate": {
+      "title": "Find duplicates",
+      "description": "Scan folders to find duplicate images and free up space."
+    },
+    "import": {
+      "title": "Import images",
+      "description": "Add new images and organize your collection. You can also drag files here."
+    }
+  }
+}

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -1,0 +1,59 @@
+{
+  "duplicate": {
+    "title": "Duplicate",
+    "choose": "Choose folder & scan",
+    "scan": "Scan",
+    "scanning": "Scanning…",
+    "deleteMarked": "Delete marked",
+    "autoMark": "Auto mark",
+    "confirmDelete": "Are you sure you want to delete {count} files?",
+    "dragDropInstruction": "Drag and drop",
+    "orClickToSelect": "or click",
+    "modes": {
+      "exact": "Exact",
+      "perceptual": "Perceptual",
+      "title": "Detection modes"
+    },
+    "tags": {
+      "hash": "Exact match",
+      "dhash": "Perceptual match"
+    },
+    "exactTooltip": "Only find files that are completely identical.",
+    "perceptualTooltip": "Also detect images that look the same even if the files are different.",
+    "subtitle": "Find duplicate images",
+    "destinationLabel": "Folder to scan:",
+    "resultsTitle": "{count} duplicate groups found",
+    "advancedOptions": "Advanced options",
+    "sensitivityLabel": "Sensitivity:",
+    "sensitivityTooltip": "Higher values find more differences"
+  },
+  "common": {
+    "keep": "keep",
+    "delete": "delete",
+    "yes": "Yes",
+    "no": "No",
+    "cancel": "Cancel"
+  },
+  "import": {
+    "title": "Import",
+    "choose": "Choose destination",
+    "destination": "Destination:",
+    "devices": "External devices",
+    "refresh": "Refresh",
+    "copy": "Copy images",
+    "no_devices_found": "No Devices found",
+    "connect_device_prompt": "Please connect a device and click refresh."
+  },
+  "home": {
+    "title": "Welcome to Image Mami",
+    "subtitle": "What would you like to do?",
+    "duplicate": {
+      "title": "Find duplicates",
+      "description": "Scan folders to find duplicate images and free up space."
+    },
+    "import": {
+      "title": "Import images",
+      "description": "Add new images and organize your collection. You can also drag files here."
+    }
+  }
+}

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1,0 +1,59 @@
+{
+  "duplicate": {
+    "title": "Duplicate",
+    "choose": "Choose folder & scan",
+    "scan": "Scan",
+    "scanning": "Scanning…",
+    "deleteMarked": "Delete marked",
+    "autoMark": "Auto mark",
+    "confirmDelete": "Are you sure you want to delete {count} files?",
+    "dragDropInstruction": "Drag and drop",
+    "orClickToSelect": "or click",
+    "modes": {
+      "exact": "Exact",
+      "perceptual": "Perceptual",
+      "title": "Detection modes"
+    },
+    "tags": {
+      "hash": "Exact match",
+      "dhash": "Perceptual match"
+    },
+    "exactTooltip": "Only find files that are completely identical.",
+    "perceptualTooltip": "Also detect images that look the same even if the files are different.",
+    "subtitle": "Find duplicate images",
+    "destinationLabel": "Folder to scan:",
+    "resultsTitle": "{count} duplicate groups found",
+    "advancedOptions": "Advanced options",
+    "sensitivityLabel": "Sensitivity:",
+    "sensitivityTooltip": "Higher values find more differences"
+  },
+  "common": {
+    "keep": "keep",
+    "delete": "delete",
+    "yes": "Yes",
+    "no": "No",
+    "cancel": "Cancel"
+  },
+  "import": {
+    "title": "Import",
+    "choose": "Choose destination",
+    "destination": "Destination:",
+    "devices": "External devices",
+    "refresh": "Refresh",
+    "copy": "Copy images",
+    "no_devices_found": "No Devices found",
+    "connect_device_prompt": "Please connect a device and click refresh."
+  },
+  "home": {
+    "title": "Welcome to Image Mami",
+    "subtitle": "What would you like to do?",
+    "duplicate": {
+      "title": "Find duplicates",
+      "description": "Scan folders to find duplicate images and free up space."
+    },
+    "import": {
+      "title": "Import images",
+      "description": "Add new images and organize your collection. You can also drag files here."
+    }
+  }
+}

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1,0 +1,59 @@
+{
+  "duplicate": {
+    "title": "Duplicate",
+    "choose": "Choose folder & scan",
+    "scan": "Scan",
+    "scanning": "Scanning…",
+    "deleteMarked": "Delete marked",
+    "autoMark": "Auto mark",
+    "confirmDelete": "Are you sure you want to delete {count} files?",
+    "dragDropInstruction": "Drag and drop",
+    "orClickToSelect": "or click",
+    "modes": {
+      "exact": "Exact",
+      "perceptual": "Perceptual",
+      "title": "Detection modes"
+    },
+    "tags": {
+      "hash": "Exact match",
+      "dhash": "Perceptual match"
+    },
+    "exactTooltip": "Only find files that are completely identical.",
+    "perceptualTooltip": "Also detect images that look the same even if the files are different.",
+    "subtitle": "Find duplicate images",
+    "destinationLabel": "Folder to scan:",
+    "resultsTitle": "{count} duplicate groups found",
+    "advancedOptions": "Advanced options",
+    "sensitivityLabel": "Sensitivity:",
+    "sensitivityTooltip": "Higher values find more differences"
+  },
+  "common": {
+    "keep": "keep",
+    "delete": "delete",
+    "yes": "Yes",
+    "no": "No",
+    "cancel": "Cancel"
+  },
+  "import": {
+    "title": "Import",
+    "choose": "Choose destination",
+    "destination": "Destination:",
+    "devices": "External devices",
+    "refresh": "Refresh",
+    "copy": "Copy images",
+    "no_devices_found": "No Devices found",
+    "connect_device_prompt": "Please connect a device and click refresh."
+  },
+  "home": {
+    "title": "Welcome to Image Mami",
+    "subtitle": "What would you like to do?",
+    "duplicate": {
+      "title": "Find duplicates",
+      "description": "Scan folders to find duplicate images and free up space."
+    },
+    "import": {
+      "title": "Import images",
+      "description": "Add new images and organize your collection. You can also drag files here."
+    }
+  }
+}

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1,0 +1,59 @@
+{
+  "duplicate": {
+    "title": "Duplicate",
+    "choose": "Choose folder & scan",
+    "scan": "Scan",
+    "scanning": "Scanning…",
+    "deleteMarked": "Delete marked",
+    "autoMark": "Auto mark",
+    "confirmDelete": "Are you sure you want to delete {count} files?",
+    "dragDropInstruction": "Drag and drop",
+    "orClickToSelect": "or click",
+    "modes": {
+      "exact": "Exact",
+      "perceptual": "Perceptual",
+      "title": "Detection modes"
+    },
+    "tags": {
+      "hash": "Exact match",
+      "dhash": "Perceptual match"
+    },
+    "exactTooltip": "Only find files that are completely identical.",
+    "perceptualTooltip": "Also detect images that look the same even if the files are different.",
+    "subtitle": "Find duplicate images",
+    "destinationLabel": "Folder to scan:",
+    "resultsTitle": "{count} duplicate groups found",
+    "advancedOptions": "Advanced options",
+    "sensitivityLabel": "Sensitivity:",
+    "sensitivityTooltip": "Higher values find more differences"
+  },
+  "common": {
+    "keep": "keep",
+    "delete": "delete",
+    "yes": "Yes",
+    "no": "No",
+    "cancel": "Cancel"
+  },
+  "import": {
+    "title": "Import",
+    "choose": "Choose destination",
+    "destination": "Destination:",
+    "devices": "External devices",
+    "refresh": "Refresh",
+    "copy": "Copy images",
+    "no_devices_found": "No Devices found",
+    "connect_device_prompt": "Please connect a device and click refresh."
+  },
+  "home": {
+    "title": "Welcome to Image Mami",
+    "subtitle": "What would you like to do?",
+    "duplicate": {
+      "title": "Find duplicates",
+      "description": "Scan folders to find duplicate images and free up space."
+    },
+    "import": {
+      "title": "Import images",
+      "description": "Add new images and organize your collection. You can also drag files here."
+    }
+  }
+}

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1,0 +1,59 @@
+{
+  "duplicate": {
+    "title": "Duplicate",
+    "choose": "Choose folder & scan",
+    "scan": "Scan",
+    "scanning": "Scanning…",
+    "deleteMarked": "Delete marked",
+    "autoMark": "Auto mark",
+    "confirmDelete": "Are you sure you want to delete {count} files?",
+    "dragDropInstruction": "Drag and drop",
+    "orClickToSelect": "or click",
+    "modes": {
+      "exact": "Exact",
+      "perceptual": "Perceptual",
+      "title": "Detection modes"
+    },
+    "tags": {
+      "hash": "Exact match",
+      "dhash": "Perceptual match"
+    },
+    "exactTooltip": "Only find files that are completely identical.",
+    "perceptualTooltip": "Also detect images that look the same even if the files are different.",
+    "subtitle": "Find duplicate images",
+    "destinationLabel": "Folder to scan:",
+    "resultsTitle": "{count} duplicate groups found",
+    "advancedOptions": "Advanced options",
+    "sensitivityLabel": "Sensitivity:",
+    "sensitivityTooltip": "Higher values find more differences"
+  },
+  "common": {
+    "keep": "keep",
+    "delete": "delete",
+    "yes": "Yes",
+    "no": "No",
+    "cancel": "Cancel"
+  },
+  "import": {
+    "title": "Import",
+    "choose": "Choose destination",
+    "destination": "Destination:",
+    "devices": "External devices",
+    "refresh": "Refresh",
+    "copy": "Copy images",
+    "no_devices_found": "No Devices found",
+    "connect_device_prompt": "Please connect a device and click refresh."
+  },
+  "home": {
+    "title": "Welcome to Image Mami",
+    "subtitle": "What would you like to do?",
+    "duplicate": {
+      "title": "Find duplicates",
+      "description": "Scan folders to find duplicate images and free up space."
+    },
+    "import": {
+      "title": "Import images",
+      "description": "Add new images and organize your collection. You can also drag files here."
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,11 +5,25 @@ import router from './router';
 import { createI18n } from 'vue-i18n';
 import en from './locales/en.json';
 import de from './locales/de.json';
+import es from './locales/es.json';
+import zh from './locales/zh.json';
+import fr from './locales/fr.json';
+import pt from './locales/pt.json';
+import ja from './locales/ja.json';
+import hi from './locales/hi.json';
+import ru from './locales/ru.json';
 import './style.css';
 
 const messages = {
   en,
   de,
+  es,
+  zh,
+  fr,
+  pt,
+  ja,
+  hi,
+  ru,
 };
 
 const i18n = createI18n({


### PR DESCRIPTION
## Summary
- include icons and placeholders for Spanish, Chinese, French, Portuguese, Japanese, Hindi and Russian
- register new locales in main setup

Build successful after running `npm run tauri build`.


------
https://chatgpt.com/codex/tasks/task_e_688b198e1fe88329baa39f7dd332c7fa